### PR TITLE
Fix the describe link 'not foud' error.

### DIFF
--- a/pkg/kfapp/coordinator/coordinator.go
+++ b/pkg/kfapp/coordinator/coordinator.go
@@ -173,13 +173,9 @@ func usageReportWarn(components []string) {
 		"To disable it\n" +
 		"If you have already deployed it run the following commands:\n" +
 		"  cd $(pwd)\n" +
-		"  ks delete default -c spartakus\n" +
 		"  kubectl -n ${K8S_NAMESPACE} delete deploy -l app=spartakus\n" +
 		"\n" +
-		"Then run the following command to remove it from your ksonnet app:\n" +
-		"  ks component rm spartakus\n" +
-		"\n" +
-		"For more info: https://www.kubeflow.org/docs/guides/usage-reporting/\n" +
+		"For more info: https://www.kubeflow.org/docs/other-guides/usage-reporting/\n" +
 		"****************************************************************\n" +
 		"\n"
 	for _, comp := range components {


### PR DESCRIPTION
When execute the CMD: `kfctl generate all -V`
```INFO[0000] Downloading /root/llhu/mykube/app.yaml to /tmp/767844227/app.yaml  filename="v1alpha1/application_types.go:334"
INFO[0000] Writing stripped KfDef to /root/llhu/mykube/app.yaml  filename="v1alpha1/application_types.go:626"
INFO[0000] Downloading /root/llhu/mykube/app.yaml to /tmp/557907718/app.yaml  filename="v1alpha1/application_types.go:334"
INFO[0000] 
****************************************************************
Notice anonymous usage reporting enabled using spartakus
To disable it
If you have already deployed it run the following commands:
  cd $(pwd)
  ks delete default -c spartakus
  kubectl -n ${K8S_NAMESPACE} delete deploy -l app=spartakus

Then run the following command to remove it from your ksonnet app:
  ks component rm spartakus

For more info: https://www.kubeflow.org/docs/guides/usage-reporting/```
****************************************************************

The above link 'For more info' can't be fond.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/9)
<!-- Reviewable:end -->
