### PR TITLE
Build kfctl in Dockerfile with Alpine based image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,8 @@ RUN make build-kfctl
 #
 
 FROM alpine:$ALPINE_VERSION as barebones_base
-RUN apk add --no-cache ca-certificates  # needed by kfctl
+# ca-certificates is needed by kfctl to download archives from HTTPS URIs
+RUN apk add --no-cache ca-certificates
 RUN mkdir -p /opt/kubeflow
 WORKDIR /opt/kubeflow
 


### PR DESCRIPTION
I'm not sure if this is used, but the `Dockerfile` produces an image that is not functional. The build image is Debian based (glibc) but the final runtime image is Alpine based (musl). There are three possible fixes:
* Switch the build image to Alpine
* Add libc6-compat to the runtime image
* Switch the runtime image to Debian or Distroless

I've arbitrarily chosen the first option and fixed up the `sh` and `sleep` commands. Additionally, `ca-certificates` is needed for `kfctl init` to complete successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/28)
<!-- Reviewable:end -->
