### PR TITLE
Fix syntax error in v1beta1

### DIFF
--- a/pkg/apis/apps/kfdef/v1beta1/application_types_test.go
+++ b/pkg/apis/apps/kfdef/v1beta1/application_types_test.go
@@ -17,7 +17,7 @@ type FakeOAuthSecret struct {
 
 type FakeIap struct {
 	OAuthClientId     string          `json:"oAuthClientId,omitempty"`
-	OAuthClientSecret FakeOAuthSecret `json::"oAuthClientSecret,omitempty"`
+	OAuthClientSecret FakeOAuthSecret `json:"oAuthClientSecret,omitempty"`
 }
 
 type FakeAuth struct {


### PR DESCRIPTION
Get error build kfctl and seems we have a syntax bug.

```
 make build-kfctl
# github.com/kubeflow/kfctl/v3/pkg/apis/apps/kfdef/v1beta1
pkg/apis/apps/kfdef/v1beta1/application_types_test.go:20:2: struct field tag `json::"oAuthClientSecret,omitempty"` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
make: *** [vet] Error 2

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/38)
<!-- Reviewable:end -->
