### PR TITLE
keep literal secret when convert kfdef v1beta1 to kfconfig

### DIFF
--- a/pkg/apis/apps/configconverters/v1beta1.go
+++ b/pkg/apis/apps/configconverters/v1beta1.go
@@ -136,15 +136,15 @@ func (v V1beta1) ToKfConfig(kfdefBytes []byte) (*kfconfig.KfConfig, error) {
 		s := kfconfig.Secret{
 			Name: secret.Name,
 		}
-		// We don't want to store literalSource explictly, becasue we want the config to be checked into source control and don't want secrets in source control.
-		if secret.SecretSource == nil || secret.SecretSource.LiteralSource != nil {
-			config.Spec.Secrets = append(config.Spec.Secrets, s)
-			continue
-		}
 		src := &kfconfig.SecretSource{}
 		if secret.SecretSource.EnvSource != nil {
 			src.EnvSource = &kfconfig.EnvSource{
 				Name: secret.SecretSource.EnvSource.Name,
+			}
+		}
+		if secret.SecretSource.LiteralSource != nil {
+			src.LiteralSource = &kfconfig.LiteralSource{
+				Value: secret.SecretSource.LiteralSource.Value,
 			}
 		}
 		s.SecretSource = src


### PR DESCRIPTION
We should not need to trim secret when convert kfdef to kfconfig:
kfconfig should be internal data structure and will not be saved to any file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/98)
<!-- Reviewable:end -->
