### PR TITLE
Fix kfctl_path in second_apply

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -20,6 +20,7 @@ workflows:
       - cmd/*
       - pkg/*
       - testing/*
+      - py/*
   - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
     name: kfctl-go-iap
     job_types:
@@ -31,6 +32,7 @@ workflows:
       - cmd/*
       - pkg/*
       - testing/*
+      - py/*
     kwargs:
       use_basic_auth: false
       # Run build and then apply rather than just apply
@@ -50,6 +52,7 @@ workflows:
       - cmd/*
       - pkg/*
       - testing/*
+      - py/*
     kwargs:
       use_basic_auth: true
       build_and_apply: true
@@ -71,6 +74,7 @@ workflows:
       - cmd/*
       - pkg/*
       - testing/*
+      - py/*
     params:
       platform: gke
       gkeApiVersion: v1

--- a/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
+++ b/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
@@ -623,6 +623,7 @@ class Builder:
            # Test suite name needs to be unique based on parameters
            "-o", "junit_suite_name=test_kfctl_second_apply_" + self.config_name,
            "--app_path=" + self.app_dir,
+           "--kfctl_path=" + self.kfctl_path,
          ]
     if self.test_endpoint:
       dependences = [kf_is_ready["name"], endpoint_ready["name"]]

--- a/py/kubeflow/kfctl/testing/ci/kfctl_go_deploy_test.py
+++ b/py/kubeflow/kfctl/testing/ci/kfctl_go_deploy_test.py
@@ -7,7 +7,7 @@ import kfctl_go_test_utils as kfctl_util
 from kubeflow.testing import util
 
 def test_deploy_kfctl_go(record_xml_attribute, app_path, project,
-                         use_basic_auth, use_istio, config_path):
+                         use_basic_auth, use_istio, config_path, kfctl_path):
   """Test deploying Kubeflow.
 
   Args:
@@ -22,8 +22,6 @@ def test_deploy_kfctl_go(record_xml_attribute, app_path, project,
       "gcloud", "auth", "activate-service-account",
       "--key-file=" + os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
     ])
-
-  _, kfctl_path = kfctl_util.get_kfctl_go_build_dir_binary_path()
 
   kfctl_util.kfctl_deploy_kubeflow(app_path, project, use_basic_auth,
               use_istio, config_path, kfctl_path)

--- a/py/kubeflow/kfctl/testing/pytests/kfctl_second_apply.py
+++ b/py/kubeflow/kfctl/testing/pytests/kfctl_second_apply.py
@@ -7,7 +7,7 @@ from kubeflow.kfctl.testing.util import kfctl_go_test_utils as kfctl_util
 from kubeflow.testing import util
 
 
-@pytest.mark.skipif(os.getenv("JOB_TYPE") == "postsubmit",
+@pytest.mark.skipif(os.getenv("JOB_TYPE") == "presubmit",
                     reason="test second apply doesn't run in presubmits")
 def test_second_apply(record_xml_attribute, app_path, kfctl_path):
   """Test that we can run kfctl apply again with error.

--- a/py/kubeflow/kfctl/testing/pytests/kfctl_second_apply.py
+++ b/py/kubeflow/kfctl/testing/pytests/kfctl_second_apply.py
@@ -9,14 +9,13 @@ from kubeflow.testing import util
 
 @pytest.mark.skipif(os.getenv("JOB_TYPE") == "presubmit",
                     reason="test second apply doesn't run in presubmits")
-def test_second_apply(record_xml_attribute, app_path):
+def test_second_apply(record_xml_attribute, app_path, kfctl_path):
   """Test that we can run kfctl apply again with error.
 
   Args:
-    kfctl_path: The path to kfctl binary.
     app_path: The app dir of kubeflow deployment.
+    kfctl_path: The path to kfctl binary.
   """
-  _, kfctl_path = kfctl_util.get_kfctl_go_build_dir_binary_path()
   if not os.path.exists(kfctl_path):
     msg = "kfctl Go binary not found: {path}".format(path=kfctl_path)
     logging.error(msg)

--- a/py/kubeflow/kfctl/testing/pytests/kfctl_second_apply.py
+++ b/py/kubeflow/kfctl/testing/pytests/kfctl_second_apply.py
@@ -7,7 +7,7 @@ from kubeflow.kfctl.testing.util import kfctl_go_test_utils as kfctl_util
 from kubeflow.testing import util
 
 
-@pytest.mark.skipif(os.getenv("JOB_TYPE") == "presubmit",
+@pytest.mark.skipif(os.getenv("JOB_TYPE") == "postsubmit",
                     reason="test second apply doesn't run in presubmits")
 def test_second_apply(record_xml_attribute, app_path, kfctl_path):
   """Test that we can run kfctl apply again with error.


### PR DESCRIPTION
We removed the function that finds paths using relative paths.  Didn't update this pytest as well.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/101)
<!-- Reviewable:end -->
