### PR TITLE
Set depth=all when checking out a specific branch

### DIFF
--- a/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
+++ b/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
@@ -511,9 +511,22 @@ class Builder:
     repos = util.combine_repos(list_of_repos)
     repos_str = ','.join(['%s@%s' % (key, value) for (key, value) in repos.items()])
 
+
+    # If we are using a specific branch (e.g. periodic tests for release branch)
+    # then we need to use depth = all; otherwise checkout out the branch
+    # will fail. Otherwise we checkout with depth=30. We want more than
+    # depth=1 because the depth will determine our ability to find the common
+    # ancestor which affects our ability to determine which files have changed
+    depth = 30
+    if os.getenv("BRANCH_NAME"):
+      logging.info("BRANCH_NAME=%s; setting detph=all",
+                   os.getenv("BRANCH_NAME"))
+      depth = "all"
+
     checkout["name"] = "checkout"
     checkout["container"]["command"] = ["/usr/local/bin/checkout_repos.sh",
                                         "--repos=" + repos_str,
+                                        "--depth={0}".format(depth),
                                         "--src_dir=" + self.src_root_dir]
 
     argo_build_util.add_task_to_dag(self.workflow, E2E_DAG_NAME, checkout, [])


### PR DESCRIPTION
* If we need a specific branch then we can't clone with depth=2 we need to use
  depth=all; otherwise the checkout of the branch will fail

* The periodic tests for the v0.7-branch are currently failing because the
  checkout is failing because we can't checkout the requested
  branch kubeflow/testing#498

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/112)
<!-- Reviewable:end -->
