### PR TITLE
Add kubeflow/kfctl to list of the default repos.

### DIFF
--- a/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
+++ b/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
@@ -65,6 +65,7 @@ TESTS_DAG_NAME = "gke-tests"
 TEMPLATE_LABEL = "kfctl_e2e"
 
 DEFAULT_REPOS = [
+    "kubeflow/kfctl@HEAD",
     "kubeflow/kubeflow@HEAD",
     "kubeflow/testing@HEAD",
     "kubeflow/tf-operator@HEAD"


### PR DESCRIPTION
* We need this because we want to be able to trigger the E2E tests from other
  repositories like kubeflow/manifests

* Related to kubeflow/manifests#613

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/133)
<!-- Reviewable:end -->
