### PR TITLE
Allow the src root directory to be substituted into the config_path.

### DIFF
--- a/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
+++ b/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
@@ -135,6 +135,15 @@ class Builder:
     # Top level directories for python testing code in kfctl.
     self.kfctl_py = os.path.join(self.src_dir, "py")
 
+    # Build a string of key value pairs that can be passed to various test
+    # steps to allow them to do substitution into different values.
+    values = {
+      "srcrootdir": self.src_root_dir,
+    }
+
+    value_pairs = ["{0}={1}".format(k,v) for k,v in values.items()]
+    self.values_str = ",".join(value_pairs)
+
     # The directory within the kubeflow_testing submodule containing
     # py scripts to use.
     self.kubeflow_testing_py = self.src_root_dir + "/kubeflow/testing/py"
@@ -564,6 +573,7 @@ class Builder:
         "-s",
         "--app_name=" + self.app_name,
         "--config_path=" + self.config_path,
+        "--values=" + self.values_str,
         "--build_and_apply=" + str(self.build_and_apply),
         # Increase the log level so that info level log statements show up.
         # TODO(https://github.com/kubeflow/testing/issues/372): If we

--- a/py/kubeflow/kfctl/testing/pytests/conftest.py
+++ b/py/kubeflow/kfctl/testing/pytests/conftest.py
@@ -4,7 +4,7 @@ def pytest_addoption(parser):
   parser.addoption(
       "--app_path", action="store", default="",
       help="Path where the KF application should be stored")
-  
+
   parser.addoption(
       "--app_name", action="store", default="",
       help="Name of the KF application")
@@ -24,10 +24,19 @@ def pytest_addoption(parser):
   parser.addoption(
       "--project", action="store", default="kubeflow-ci-deployment",
       help="GCP project to deploy Kubeflow to")
-  
+
   parser.addoption(
       "--config_path", action="store", default="",
-      help="The config to use for kfctl init")
+      help=("The config to use for kfctl init. The path can use python style "
+            "go format strings; e.g. "
+            "--config_path=/{srcdir}/kubeflow/manifests/kfdef/kfctl_gcp.yaml"
+            " The values should be supplied by --values."))
+
+  parser.addoption(
+      "--values", action="store", default="",
+      help=("A comma separated list of key value pairs to be used for "
+            "subsitution in --config_path"))
+
   parser.addoption(
       "--build_and_apply", action="store", default="False",
       help="Whether to build and apply or apply in kfctl"

--- a/py/kubeflow/kfctl/testing/pytests/conftest.py
+++ b/py/kubeflow/kfctl/testing/pytests/conftest.py
@@ -92,6 +92,10 @@ def config_path(request):
   return request.config.getoption("--config_path")
 
 @pytest.fixture
+def values(request):
+  return request.config.getoption("--values")
+
+@pytest.fixture
 def cluster_creation_script(request):
   return request.config.getoption("--cluster_creation_script")
 

--- a/py/kubeflow/kfctl/testing/pytests/kfctl_go_test.py
+++ b/py/kubeflow/kfctl/testing/pytests/kfctl_go_test.py
@@ -9,7 +9,7 @@ from kubeflow.testing import util
 
 def test_build_kfctl_go(record_xml_attribute, app_name, app_path, project, use_basic_auth,
                         use_istio, config_path, build_and_apply, kfctl_repo_path,
-                        cluster_creation_script, self_signed_cert):
+                        cluster_creation_script, self_signed_cert, values):
   """Test building and deploying Kubeflow.
 
   Args:
@@ -23,6 +23,7 @@ def test_build_kfctl_go(record_xml_attribute, app_name, app_path, project, use_b
     build_and_apply: whether to build and apply or apply
     kfctl_repo_path: path to the kubeflow/kfctl repo.
     self_signed_cert: whether to use self-signed cert for ingress.
+    values: Comma separated list of variables to substitute into config_path
   """
   util.set_pytest_junit(record_xml_attribute, "test_build_kfctl_go")
 
@@ -40,6 +41,17 @@ def test_build_kfctl_go(record_xml_attribute, app_name, app_path, project, use_b
 
 
   logging.info("using kfctl repo: %s" % kfctl_repo_path)
+
+  if values:
+    pairs = values.split(",")
+    path_vars = {}
+    for p in pairs:
+      k, v = p.split("=")
+      path_vars[k] = v
+
+    config_path = config_path.format(**path_vars)
+    logging.info("config_path after substitution: %s", config_path)
+
   kfctl_path = kfctl_util.build_kfctl_go(kfctl_repo_path)
   app_path = kfctl_util.kfctl_deploy_kubeflow(
                   app_path, project, use_basic_auth,


### PR DESCRIPTION
* When testing kfctl, we want to be able to use a config_path that pulls
  the KFDef from a local path where we have checked out kubeflow/manifests

* To do that we need to be able to substitute in the path for the local
  directory where the source is checked out.

* This PR changes kfctl_go_test.py so we can use python style format strings
  in the config_path. The key value pairs are passed by a separate argument.

* kfctl_e2e_workflow.py then creates a values string which contains the
  variable srcrootdir.

* This will allow us to create prowconfig values that set config_path to
  {srcrootdir}/kubeflow/manifests/kfdef/kfctl_gcp_iap.yaml

Related to kubeflow/manifests#613

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/134)
<!-- Reviewable:end -->
