### PR TITLE
disable dex test

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -59,30 +59,30 @@ workflows:
       test_endpoint: true
       config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_gcp_basic_auth.yaml
   # E2E tests for kfctl_istio_dex
-  - app_dir: kubeflow/kubeflow/testing/workflows
-    component: kfctl_go_test
-    name: kfctl-go-dex
-    job_types:
-      # Enable once we have confirmed the stability of the test
-      # - presubmit
-      # TODO(jlewi): I don't think we want to enable on presubmit.
-      # see https://github.com/kubeflow/kfctl/issues/57
-      - postsubmit
-      - periodic
-    include_dirs:
-      - config/*
-      - cmd/*
-      - pkg/*
-      - testing/*
-      - py/*
-    params:
-      platform: gke
-      gkeApiVersion: v1
-      workflowName: kfctl-go
-      useBasicAuth: false
-      useIstio: true
-      testEndpoint: false
-      configPath: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_istio_dex.yaml
-      cluster_creation_script: create_existing_cluster.sh
-      cluster_deletion_script: delete_existing_cluster.py
-      nameSuffix: dex
+  # - app_dir: kubeflow/kubeflow/testing/workflows
+  #   component: kfctl_go_test
+  #   name: kfctl-go-dex
+  #   job_types:
+  #     # Enable once we have confirmed the stability of the test
+  #     # - presubmit
+  #     # TODO(jlewi): I don't think we want to enable on presubmit.
+  #     # see https://github.com/kubeflow/kfctl/issues/57
+  #     - postsubmit
+  #     - periodic
+  #   include_dirs:
+  #     - config/*
+  #     - cmd/*
+  #     - pkg/*
+  #     - testing/*
+  #     - py/*
+  #   params:
+  #     platform: gke
+  #     gkeApiVersion: v1
+  #     workflowName: kfctl-go
+  #     useBasicAuth: false
+  #     useIstio: true
+  #     testEndpoint: false
+  #     configPath: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_istio_dex.yaml
+  #     cluster_creation_script: create_existing_cluster.sh
+  #     cluster_deletion_script: delete_existing_cluster.py
+  #     nameSuffix: dex


### PR DESCRIPTION
Related: kubeflow/testing#542

Disable the test until we could verify it runs again.

@yanniszark could you help update the test to use the new semantics - write pytest suite and use pyfunc to create the workflow?  you could check how gcp_iap test does it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/136)
<!-- Reviewable:end -->
