### PR TITLE
Fix SyncCache with local tarball file

### DIFF
--- a/pkg/kfconfig/types.go
+++ b/pkg/kfconfig/types.go
@@ -513,12 +513,10 @@ func (c *KfConfig) SyncCache() error {
 					Code:    int(kfapis.INVALID_ARGUMENT),
 					Message: fmt.Sprintf("couldn't stat the path %v: %v", filePath, err),
 				}
-			} else {
-				if !fileInfo.IsDir() {
-					subdir := files[0].Name()
-					localPath = path.Join(cacheDir, subdir)
-					log.Infof("updating localPath to %v", localPath)
-				}
+			} else if !fileInfo.IsDir() {
+				subdir := files[0].Name()
+				localPath = path.Join(cacheDir, subdir)
+				log.Infof("updating localPath to %v", localPath)
 			}
 		}
 

--- a/pkg/kfconfig/types.go
+++ b/pkg/kfconfig/types.go
@@ -496,14 +496,30 @@ func (c *KfConfig) SyncCache() error {
 		// This is a bit of a hack to deal with the fact that GitHub tarballs
 		// can unpack to a directory containing the commit.
 		localPath := cacheDir
+		files, filesErr := ioutil.ReadDir(cacheDir)
+		if filesErr != nil {
+			log.Errorf("Error reading cachedir; error %v", filesErr)
+			return errors.WithStack(filesErr)
+		}
 		if u.Scheme == "http" || u.Scheme == "https" {
-			files, filesErr := ioutil.ReadDir(cacheDir)
-			if filesErr != nil {
-				log.Errorf("Error reading cachedir; error %v", filesErr)
-				return errors.WithStack(filesErr)
-			}
 			subdir := files[0].Name()
 			localPath = path.Join(cacheDir, subdir)
+			log.Infof("updating localPath to %v", localPath)
+		} else if u.Scheme == "file" {
+			filePath := strings.TrimPrefix(r.URI, "file:")
+			log.Infof("probing file path: %v", filePath)
+			if fileInfo, err := os.Stat(filePath); err != nil {
+				return &kfapis.KfError{
+					Code:    int(kfapis.INVALID_ARGUMENT),
+					Message: fmt.Sprintf("couldn't stat the path %v: %v", filePath, err),
+				}
+			} else {
+				if !fileInfo.IsDir() {
+					subdir := files[0].Name()
+					localPath = path.Join(cacheDir, subdir)
+					log.Infof("updating localPath to %v", localPath)
+				}
+			}
 		}
 
 		c.Status.Caches = append(c.Status.Caches, Cache{

--- a/pkg/kfconfig/types_test.go
+++ b/pkg/kfconfig/types_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/prometheus/common/log"
+	"io"
 	"io/ioutil"
 	"os"
 	"path"
@@ -44,6 +45,21 @@ func TestSyncCache(t *testing.T) {
 
 	ioutil.WriteFile(path.Join(srcDir, "file1"), []byte("hello world"), os.ModePerm)
 
+	// Verify that we can unpack a local tarball and use it.
+	tarballName := "c0e81bedec9a4df8acf568cc5ccacc4bc05a3b38.tar.gz"
+	from, err := os.Open(path.Join("./testdata", tarballName))
+	if err != nil {
+		t.Fatalf("failed to open tarball file: %v", err)
+	}
+	tarballPath := path.Join(srcDir, tarballName)
+	to, err := os.OpenFile(tarballPath, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("failed to open new file location fortarball file: %v", err)
+	}
+	if _, err = io.Copy(to, from); err != nil {
+		t.Fatalf("tarball copy is failed: %v", err)
+	}
+
 	repoName := "testRepo"
 
 	testCases := []testCase{
@@ -62,6 +78,24 @@ func TestSyncCache(t *testing.T) {
 				{
 					Name:      repoName,
 					LocalPath: path.Join(testDir, "app1", ".cache", repoName),
+				},
+			},
+		},
+		{
+			input: &KfConfig{
+				Spec: KfConfigSpec{
+					AppDir: path.Join(testDir, "app2"),
+					Repos: []Repo{{
+						Name: repoName,
+						URI:  "file:" + tarballPath,
+					},
+					},
+				},
+			},
+			expected: []Cache{
+				{
+					Name:      repoName,
+					LocalPath: path.Join(testDir, "app2", ".cache", repoName, "kubeflow-manifests-c0e81be"),
 				},
 			},
 		},


### PR DESCRIPTION
Fixes: kubeflow/kubeflow#4561

When scheme is file, it doesn't necessary the target is a manifest folder.  Codes break when the target is a local tarball.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/145)
<!-- Reviewable:end -->
