### PR TITLE
Basic auth endpoint fix

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -43,7 +43,7 @@ workflows:
       config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_gcp_iap.yaml
   # Run basic auth test as part of every periodic and postsubmit run.
   - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
-    name: kfctl-go-basic-auth
+    name: kfctl-bauth
     job_types:
       - postsubmit
       - periodic

--- a/py/kubeflow/kfctl/testing/util/gcp_util.py
+++ b/py/kubeflow/kfctl/testing/util/gcp_util.py
@@ -123,6 +123,18 @@ def iap_is_ready(url, wait_min=15):
   return False
 
 def _send_req(wait_sec, url, req_gen):
+  """ Helper function to send requests and retry when the endpoint is not ready.
+
+  Args:
+  wait_sec: int, max time to wait and retry in seconds.
+  url: str, url to send the request, used only for logging.
+  req_gen: lambda, no parameter function to generate requests.Request for the
+  function to send to the endpoint.
+
+  Returns:
+    requests.Response
+  """
+
   # Simple identifier that we need to re-send the request.
   class RetryError(Exception):
     pass

--- a/py/kubeflow/kfctl/testing/util/gcp_util.py
+++ b/py/kubeflow/kfctl/testing/util/gcp_util.py
@@ -144,6 +144,9 @@ def _send_req(wait_sec, url, req_gen):
       logging.info(
           "%s: Endpoint not ready" % url)
       raise RetryError()
+    except Exception as e:
+      logging.error("%s: unexpected error: %s" % (url, e))
+      raise e
     if not resp or resp.status_code != 200:
       logging.info("Basic auth login is not ready: %s" % get_url)
       raise RetryError()

--- a/py/kubeflow/kfctl/testing/util/gcp_util.py
+++ b/py/kubeflow/kfctl/testing/util/gcp_util.py
@@ -145,13 +145,9 @@ def _send_req(wait_sec, url, req_gen):
           "%s: Endpoint not ready" % url)
       raise RetryError()
     except Exception as e:
-      logging.error("%s: unexpected error: %s" % (url, e))
+      logging.info("%s: unexpected error: %s" % (url, e))
       raise e
-    if not resp or resp.status_code != 200:
-      logging.info("Basic auth login is not ready: %s" % get_url)
-      raise RetryError()
-    else:
-      return resp
+    return resp
 
   return _send(url, req_gen)
 
@@ -163,10 +159,17 @@ def basic_auth_is_ready(url, username, password, wait_min=15):
       minutes=wait_min)
 
   wait_time = datetime.datetime.now() - end_time
-  resp = _send_req(wait_time.seconds, get_url, lambda: requests.request(
-      "GET",
-      get_url,
-      verify=False))
+  while True:
+    resp = _send_req(wait_time.seconds, get_url, lambda: requests.request(
+        "GET",
+        get_url,
+        verify=False))
+    # GET might returns 400 codes instead of throwing errors.
+    if not resp or resp.status_code != 200:
+      logging.info("%s: basic auth login is not ready" % get_url)
+    else:
+      break
+    sleep(10)
 
   logging.info("%s: endpoint is ready; response: %s" % (get_url, resp.text))
   logging.info("%s: testing login API" % post_url)
@@ -184,6 +187,7 @@ def basic_auth_is_ready(url, username, password, wait_min=15):
     logging.error("%s: login is failed", post_url)
     return False
 
+  logging.info("%s: testing cookies credentials" % url)
   cookie = None
   for c in resp.cookies:
     if c.name == COOKIE_NAME:

--- a/py/kubeflow/kfctl/testing/util/gcp_util.py
+++ b/py/kubeflow/kfctl/testing/util/gcp_util.py
@@ -146,7 +146,7 @@ def _send_req(wait_sec, url, req_gen, retry_result_code=None):
 
   @retry(stop_max_delay=wait_sec * 1000, wait_fixed=10 * 1000,
          retry_on_exception=retry_on_error,
-         retry_on_result=retry_on_result_func)
+         retry_on_result=retry_on_result_func(retry_result_code))
   def _send(url, req_gen):
     resp = None
     logging.info("sending request to %s" % url)

--- a/py/kubeflow/kfctl/testing/util/gcp_util.py
+++ b/py/kubeflow/kfctl/testing/util/gcp_util.py
@@ -149,14 +149,22 @@ def basic_auth_is_ready(url, username, password, wait_min=15):
       break
     sleep(10)
 
-  logging.info("%s: endpoint is ready, testing login API; request number %s" % (get_url, req_num))
-  resp = requests.post(
-      post_url,
-      auth=(username, password),
-      headers={
-          "x-from-login": "true",
-      },
-      verify=False)
+  resp = None
+  while datetime.datetime.now() < end_time:
+    req_num += 1
+    logging.info("%s: endpoint is ready, testing login API; request number %s" % (get_url, req_num))
+    try:
+      resp = requests.post(
+          post_url,
+          auth=(username, password),
+          headers={
+              "x-from-login": "true",
+          },
+          verify=False)
+    except SSLError as e:
+      logging.warning("%s: Endpoint SSL handshake error: %s; request number: %s" % (url, e, req_num))
+    sleep(10)
+
   logging.info("%s: %s" % (post_url, resp.text))
   if resp.status_code != 205:
     logging.error("%s: login is failed", post_url)

--- a/py/kubeflow/kfctl/testing/util/gcp_util.py
+++ b/py/kubeflow/kfctl/testing/util/gcp_util.py
@@ -136,7 +136,7 @@ def _send_req(wait_sec, url, req_gen, retry_result_code=None):
   """
 
   def retry_on_error(e):
-    return isinstance(e, [SSLError, ReqConnectionError])
+    return isinstance(e, (SSLError, ReqConnectionError))
 
   def retry_on_result_func(code):
     if code is None:

--- a/py/kubeflow/kfctl/testing/util/gcp_util.py
+++ b/py/kubeflow/kfctl/testing/util/gcp_util.py
@@ -130,6 +130,7 @@ def _send_req(wait_sec, url, req_gen, retry_result_code=None):
   url: str, url to send the request, used only for logging.
   req_gen: lambda, no parameter function to generate requests.Request for the
   function to send to the endpoint.
+  retry_result_code: int (optional), status code to match or retry the request.
 
   Returns:
     requests.Response
@@ -138,6 +139,9 @@ def _send_req(wait_sec, url, req_gen, retry_result_code=None):
   def retry_on_error(e):
     return isinstance(e, (SSLError, ReqConnectionError))
 
+  # generates function to see if the request needs to be retried.
+  # if param `code` is None, will not retry and directly pass back the response.
+  # Otherwise will retry if status code is not matched.
   def retry_on_result_func(code):
     if code is None:
       return lambda _: False


### PR DESCRIPTION
witnessed periodic test failure due to SSL handshake error in endpoint test.  making it retry so that we don't fail on flaky calls.  also, DNS name can be too long so make it shorter for that.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/153)
<!-- Reviewable:end -->
