### PR TITLE
fix SetTokenSource

### DIFF
--- a/pkg/kfapp/gcp/gcp.go
+++ b/pkg/kfapp/gcp/gcp.go
@@ -124,6 +124,8 @@ type Setter interface {
 
 func (gcp *Gcp) SetTokenSource(s oauth2.TokenSource) error {
 	gcp.tokenSource = s
+	// Reset client to force pick up the new token
+	gcp.client = nil
 	return nil
 }
 


### PR DESCRIPTION
`gcp.SetTokenSource` should allow user set the token talking to GCP.
However `initGcpClient` now is called before all kfctl actions, which initialize a default `gcp.client`.
To fix it we need to remove the existing client during `gcp.SetTokenSource` so our token could actually been used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/176)
<!-- Reviewable:end -->
