### PR TITLE
filter secrets during "kfconfig -> kfdef" instead of "kfdef -> kfconfig"

### DIFF
--- a/pkg/kfconfig/loaders/v1.go
+++ b/pkg/kfconfig/loaders/v1.go
@@ -112,12 +112,13 @@ func (v V1) LoadKfConfig(def interface{}) (*kfconfig.KfConfig, error) {
 		s := kfconfig.Secret{
 			Name: secret.Name,
 		}
-		// We don't want to store literalSource explictly, becasue we want the config to be checked into source control and don't want secrets in source control.
+		src := &kfconfig.SecretSource{}
+		// kfdef -> kfconfig should keep  literalSource , becasue only kfdef should be checked into source control,
+		// We only filter secrets during kfconfig -> kfdef.
 		if secret.SecretSource == nil || secret.SecretSource.LiteralSource != nil {
 			config.Spec.Secrets = append(config.Spec.Secrets, s)
 			continue
 		}
-		src := &kfconfig.SecretSource{}
 		if secret.SecretSource.EnvSource != nil {
 			src.EnvSource = &kfconfig.EnvSource{
 				Name: secret.SecretSource.EnvSource.Name,
@@ -210,11 +211,7 @@ func (v V1) LoadKfDef(config kfconfig.KfConfig, out interface{}) error {
 		}
 		if secret.SecretSource != nil {
 			s.SecretSource = &kfdeftypes.SecretSource{}
-			if secret.SecretSource.LiteralSource != nil {
-				s.SecretSource.LiteralSource = &kfdeftypes.LiteralSource{
-					Value: secret.SecretSource.LiteralSource.Value,
-				}
-			}
+			// We don't want to store literalSource explictly, becasue we want the config to be checked into source control and don't want secrets in source control.
 			if secret.SecretSource.EnvSource != nil {
 				s.SecretSource.EnvSource = &kfdeftypes.EnvSource{
 					Name: secret.SecretSource.EnvSource.Name,

--- a/pkg/kfconfig/loaders/v1beta1.go
+++ b/pkg/kfconfig/loaders/v1beta1.go
@@ -112,17 +112,19 @@ func (v V1beta1) LoadKfConfig(def interface{}) (*kfconfig.KfConfig, error) {
 		s := kfconfig.Secret{
 			Name: secret.Name,
 		}
-		// We don't want to store literalSource explictly, becasue we want the config to be checked into source control and don't want secrets in source control.
+		src := &kfconfig.SecretSource{}
+		// kfdef -> kfconfig should keep  literalSource , becasue only kfdef should be checked into source control,
+		// We only filter secrets during kfconfig -> kfdef.
 		if secret.SecretSource == nil || secret.SecretSource.LiteralSource != nil {
 			config.Spec.Secrets = append(config.Spec.Secrets, s)
 			continue
 		}
-		src := &kfconfig.SecretSource{}
 		if secret.SecretSource.EnvSource != nil {
 			src.EnvSource = &kfconfig.EnvSource{
 				Name: secret.SecretSource.EnvSource.Name,
 			}
 		}
+
 		s.SecretSource = src
 		config.Spec.Secrets = append(config.Spec.Secrets, s)
 	}
@@ -210,11 +212,7 @@ func (v V1beta1) LoadKfDef(config kfconfig.KfConfig, out interface{}) error {
 		}
 		if secret.SecretSource != nil {
 			s.SecretSource = &kfdeftypes.SecretSource{}
-			if secret.SecretSource.LiteralSource != nil {
-				s.SecretSource.LiteralSource = &kfdeftypes.LiteralSource{
-					Value: secret.SecretSource.LiteralSource.Value,
-				}
-			}
+			// We don't want to store literalSource explictly, becasue we want the config to be checked into source control and don't want secrets in source control.
 			if secret.SecretSource.EnvSource != nil {
 				s.SecretSource.EnvSource = &kfdeftypes.EnvSource{
 					Name: secret.SecretSource.EnvSource.Name,


### PR DESCRIPTION
`kfdef -> kfconfig` should not need to filter secrets as kfconfig should only exist in memory.
We should filter secrets during `kfconfig -> kfdef` instead as kfdef is the format for config files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/179)
<!-- Reviewable:end -->
