### PR TITLE
Update kfupgrade prow to include more specific dirs

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -65,11 +65,10 @@ workflows:
       - postsubmit
       - periodic
     include_dirs:
-      - config/*
-      - cmd/*
-      - pkg/*
-      - testing/*
-      - py/*
+      - pkg/kfupgrade/*
+      - pkg/apis/apps/kfupgrade/*
+      - py/kubeflow/kfctl/testing/ci/kfctl_upgrade_e2e_workflow.py
+      - py/kubeflow/kfctl/testing/pytests/kfctl_upgrade_test.py
     kwargs:
       use_basic_auth: false
       # Run build and then apply rather than just apply


### PR DESCRIPTION
A quick fix on prow to only trigger kfupgrade tests when kfupgrade directories are modified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/196)
<!-- Reviewable:end -->
