### PR TITLE
Add a link to operator docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # kfctl
 kfctl is a CLI for deploying and managing Kubeflow
+
+
+## Docs
+
+* [Kubeflow Operator](./operator.md)


### PR DESCRIPTION
As there is no `docs/` directory and operator documentation is in root dir, it would be good to have a link in README

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/197)
<!-- Reviewable:end -->
