### PR TITLE
Make kfctl show and set-image-name alpha commands

### DIFF
--- a/cmd/kfctl/cmd/alpha.go
+++ b/cmd/kfctl/cmd/alpha.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	//"fmt"
+
+	//kftypes "github.com/kubeflow/kfctl/v3/pkg/apis/apps"
+	//"github.com/kubeflow/kfctl/v3/pkg/kfapp/coordinator"
+	//log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var alphaCfg = viper.New()
+
+// alphaCmd represents the commands that are in alpha
+var alphaCmd = &cobra.Command{
+	Use:   "alpha",
+	Short: "Alpha kfctl features.",
+	Long:  `Alpha kfctl features.`,
+}
+
+func init() {
+	rootCmd.AddCommand(alphaCmd)
+}

--- a/cmd/kfctl/cmd/alpha.go
+++ b/cmd/kfctl/cmd/alpha.go
@@ -1,11 +1,6 @@
 package cmd
 
 import (
-	//"fmt"
-
-	//kftypes "github.com/kubeflow/kfctl/v3/pkg/apis/apps"
-	//"github.com/kubeflow/kfctl/v3/pkg/kfapp/coordinator"
-	//log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/cmd/kfctl/cmd/set-image-name.go
+++ b/cmd/kfctl/cmd/set-image-name.go
@@ -35,7 +35,7 @@ func init() {
 		return
 	}
 
-	rootCmd.AddCommand(setImageNameCmd)
+	alphaCmd.AddCommand(setImageNameCmd)
 }
 
 var setImageNameCfg = viper.New()

--- a/cmd/kfctl/cmd/show.go
+++ b/cmd/kfctl/cmd/show.go
@@ -56,7 +56,7 @@ var showCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(showCmd)
+	alphaCmd.AddCommand(showCmd)
 
 	showCfg.SetConfigName("app")
 	showCfg.SetConfigType("yaml")


### PR DESCRIPTION
https://github.com/kubeflow/kubeflow/issues/4592

```
./bin/kfctl alpha
Alpha kfctl features.

Usage:
  kfctl alpha [command]

Available Commands:
  show        Show a generated kubeflow application.

Flags:
  -h, --help   help for alpha

Use "kfctl alpha [command] --help" for more information about a command.

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/201)
<!-- Reviewable:end -->
