### PR TITLE
use py3 img only in endpoint_is_ready

### DIFF
--- a/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
+++ b/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
@@ -555,6 +555,7 @@ class Builder(object):
     # Change the workfing directory for all subsequent steps
     task_template["container"]["workingDir"] = os.path.join(
       self.kfctl_pytest_dir)
+    py3_template["container"]["workingDir"] = os.path.join(self.kfctl_pytest_dir)
 
     #**************************************************************************
     # Run build_kfctl and deploy kubeflow

--- a/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
+++ b/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
@@ -439,8 +439,6 @@ class Builder(object):
   def _build_exit_dag(self):
     """Build the exit handler dag"""
     task_template = self._build_task_template()
-    py3_template = argo_build_util.deep_copy(task_template)
-    py3_template["container"]["image"] = "gcr.io/kubeflow-ci/test-worker-py3:789005d"
 
     #***********************************************************************
     # Delete Kubeflow
@@ -517,6 +515,8 @@ class Builder(object):
   def build(self):
     self.workflow = self._build_workflow()
     task_template = self._build_task_template()
+    py3_template = argo_build_util.deep_copy(task_template)
+    py3_template["container"]["image"] = "gcr.io/kubeflow-ci/test-worker-py3:789005d"
 
     #**************************************************************************
     # Checkout

--- a/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
+++ b/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
@@ -439,6 +439,8 @@ class Builder(object):
   def _build_exit_dag(self):
     """Build the exit handler dag"""
     task_template = self._build_task_template()
+    py3_template = argo_build_util.deep_copy(task_template)
+    py3_template["container"]["image"] = "gcr.io/kubeflow-ci/test-worker-py3:789005d"
 
     #***********************************************************************
     # Delete Kubeflow
@@ -637,8 +639,6 @@ class Builder(object):
                  "--use_basic_auth={0}".format(self.use_basic_auth),
               ]
 
-      py3_template = argo_build_util.deep_copy(task_template)
-      py3_template["container"]["image"] = "gcr.io/kubeflow-ci/test-worker-py3:789005d"
       dependencies = [build_kfctl["name"]]
       endpoint_ready = self._build_step(self._test_endpoint_step_name,
                                         self.workflow, E2E_DAG_NAME, py3_template,

--- a/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
+++ b/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
@@ -629,8 +629,6 @@ class Builder(object):
                  "-s",
                  # Increase the log level so that info level log statements show up.
                  "--log-cli-level=info",
-                 # Test timeout in seconds.
-                 "--timeout=1800",
                  "--junitxml=" + self.artifacts_dir + "/junit_endpoint-is-ready-test-" + self.config_name + ".xml",
                  # Test suite name needs to be unique based on parameters
                  "-o", "junit_suite_name=test_endpoint_is_ready_" + self.config_name,

--- a/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
+++ b/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
@@ -639,9 +639,11 @@ class Builder(object):
                  "--use_basic_auth={0}".format(self.use_basic_auth),
               ]
 
+      py3_template = argo_build_util.deep_copy(task_template)
+      py3_template["container"]["image"] = "gcr.io/kubeflow-ci/test-worker-py3:789005d"
       dependencies = [build_kfctl["name"]]
       endpoint_ready = self._build_step(self._test_endpoint_step_name,
-                                        self.workflow, E2E_DAG_NAME, task_template,
+                                        self.workflow, E2E_DAG_NAME, py3_template,
                                         command, dependencies)
       self._test_endpoint_template_name = endpoint_ready["name"]
 


### PR DESCRIPTION
fix endpoint_is_ready pytest for python2.x deprecation.  use new test-worker image on python3.

presubmit with endpoint test was passed: https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kubeflow_kfctl/245/kubeflow-kfctl-presubmit/1229917734066720768/

Related: #228

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/245)
<!-- Reviewable:end -->
