### PR TITLE
Fix license issue: update go.mod to remove bou.ke/monkey dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,8 @@ replace (
 	github.com/go-openapi/spec => github.com/go-openapi/spec v0.18.0
 	github.com/go-openapi/swag => github.com/go-openapi/swag v0.17.0
 	github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.0.0
+	github.com/otiai10/copy => github.com/otiai10/copy v1.0.2
+	github.com/otiai10/mint => github.com/otiai10/mint v1.3.0
 	github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2-0.20180428102519-11635eb403ff // indirect
 	golang.org/x/crypto => golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9
 	k8s.io/api => k8s.io/api v0.0.0-20190620084959-7cf5895f2711

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,4 @@
 bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690/go.mod h1:Ulb78X89vxKYgdL24HMTiXYHlyHEvruOj1ZPlqeNEZM=
-bou.ke/monkey v1.0.1/go.mod h1:FgHuK96Rv2Nlf+0u1OOVDpCMdsWyOFmeeketDHE7LIg=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.37.4/go.mod h1:NHPJ89PdicEuT9hdPXMROBD91xc5uRDxsMtSB16k7hw=


### PR DESCRIPTION
A dependency on `bou.ke/monkey` package was Introduced through #189. The license of that package states it is not permitted to be used by anyone, refer to https://github.com/bouk/monkey/blob/master/LICENSE.md.

The direct dependent package is `otiai10/copy` which has been modified to remove that package, refer to https://github.com/otiai10/copy/issues/12.

I have also opened a PR to fix the `operator-framework/operator-registry` package. But before a new version of that package is ready, we need the fix here so this PR updated the `go.mod` to use the right version of `otiai10/copy` and `otiai10/mint` packages to avoid the license issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/251)
<!-- Reviewable:end -->
