### PR TITLE
Kustomize cleanup error handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ ENV PATH /go/bin:/usr/local/go/bin:/opt/google-cloud-sdk/bin:${PATH}
 # use go modules
 ENV GO111MODULE=on
 ENV GOPATH=/go
+ENV GOROOT=/usr/local/go # Workaround for https://github.com/kubernetes/gengo/issues/146
 
 # Create kfctl folder
 RUN mkdir -p ${GOPATH}/src/github.com/kubeflow/kfctl

--- a/cmd/kfctl/cmd/apply.go
+++ b/cmd/kfctl/cmd/apply.go
@@ -110,7 +110,7 @@ func init() {
 		string(kftypes.VERBOSE)+" output default is false")
 	bindErr := applyCfg.BindPFlag(string(kftypes.VERBOSE), applyCmd.Flags().Lookup(string(kftypes.VERBOSE)))
 	if bindErr != nil {
-		log.Errorf("couldn't set flag --%v: %v", string(kftypes.VERBOSE), bindErr)
+		log.Errorf("Couldn't set flag --%v: %v", string(kftypes.VERBOSE), bindErr)
 		return
 	}
 }

--- a/cmd/kfctl/cmd/build.go
+++ b/cmd/kfctl/cmd/build.go
@@ -91,7 +91,7 @@ func init() {
 		string(kftypes.VERBOSE)+" output default is false")
 	bindErr := buildCfg.BindPFlag(string(kftypes.VERBOSE), buildCmd.Flags().Lookup(string(kftypes.VERBOSE)))
 	if bindErr != nil {
-		log.Errorf("couldn't set flag --%v: %v", string(kftypes.VERBOSE), bindErr)
+		log.Errorf("Couldn't set flag --%v: %v", string(kftypes.VERBOSE), bindErr)
 		return
 	}
 }

--- a/cmd/kfctl/cmd/delete.go
+++ b/cmd/kfctl/cmd/delete.go
@@ -82,7 +82,7 @@ func init() {
 		string(kftypes.VERBOSE)+" output default is false")
 	bindErr := deleteCfg.BindPFlag(string(kftypes.VERBOSE), deleteCmd.Flags().Lookup(string(kftypes.VERBOSE)))
 	if bindErr != nil {
-		log.Errorf("couldn't set flag --%v: %v", string(kftypes.VERBOSE), bindErr)
+		log.Errorf("Couldn't set flag --%v: %v", string(kftypes.VERBOSE), bindErr)
 		return
 	}
 
@@ -91,7 +91,7 @@ func init() {
 		string(kftypes.FORCE_DELETION)+" output default is false")
 	bindErr = deleteCfg.BindPFlag(string(kftypes.FORCE_DELETION), deleteCmd.Flags().Lookup(string(kftypes.FORCE_DELETION)))
 	if bindErr != nil {
-		log.Errorf("couldn't set flag --%v: %v", string(kftypes.FORCE_DELETION), bindErr)
+		log.Errorf("Couldn't set flag --%v: %v", string(kftypes.FORCE_DELETION), bindErr)
 		return
 	}
 
@@ -99,7 +99,7 @@ func init() {
 		"Set if you want to delete app's storage cluster used for mlpipeline.")
 	bindErr = deleteCfg.BindPFlag(string(kftypes.DELETE_STORAGE), deleteCmd.Flags().Lookup(string(kftypes.DELETE_STORAGE)))
 	if bindErr != nil {
-		log.Errorf("couldn't set flag --%v: %v", string(kftypes.DELETE_STORAGE), bindErr)
+		log.Errorf("Couldn't set flag --%v: %v", string(kftypes.DELETE_STORAGE), bindErr)
 		return
 	}
 }

--- a/cmd/kfctl/cmd/mirror_build.go
+++ b/cmd/kfctl/cmd/mirror_build.go
@@ -27,7 +27,7 @@ func init() {
 		string(kftypes.VERBOSE)+" output default is false")
 	bindErr := replicateBuildCfg.BindPFlag(string(kftypes.VERBOSE), replicateBuildCmd.Flags().Lookup(string(kftypes.VERBOSE)))
 	if bindErr != nil {
-		log.Errorf("couldn't set flag --%v: %v", string(kftypes.VERBOSE), bindErr)
+		log.Errorf("Couldn't set flag --%v: %v", string(kftypes.VERBOSE), bindErr)
 		return
 	}
 
@@ -69,7 +69,7 @@ Image replication rules are defined in config file.
 			return err
 		}
 		for _, pattern := range replication.Spec.Patterns {
-			log.Infof("context: %v; destination registry: %v", replication.Spec.Context, pattern.Dest)
+			log.Infof("Context: %v; destination registry: %v", replication.Spec.Context, pattern.Dest)
 			if replication.Spec.Context == "" || pattern.Dest == "" {
 				return fmt.Errorf("Config: context and dest registry cannot be empty")
 			}

--- a/cmd/kfctl/cmd/mirror_overwrite.go
+++ b/cmd/kfctl/cmd/mirror_overwrite.go
@@ -20,7 +20,7 @@ func init() {
 		string(kftypes.VERBOSE)+" output default is false")
 	bindErr := replicateOverwriteCfg.BindPFlag(string(kftypes.VERBOSE), replicateOverwriteCmd.Flags().Lookup(string(kftypes.VERBOSE)))
 	if bindErr != nil {
-		log.Errorf("couldn't set flag --%v: %v", string(kftypes.VERBOSE), bindErr)
+		log.Errorf("Couldn't set flag --%v: %v", string(kftypes.VERBOSE), bindErr)
 		return
 	}
 

--- a/cmd/kfctl/cmd/set-image-name.go
+++ b/cmd/kfctl/cmd/set-image-name.go
@@ -31,7 +31,7 @@ func init() {
 		string(kftypes.VERBOSE)+" output default is false")
 	bindErr := setImageNameCfg.BindPFlag(string(kftypes.VERBOSE), setImageNameCmd.Flags().Lookup(string(kftypes.VERBOSE)))
 	if bindErr != nil {
-		log.Errorf("couldn't set flag --%v: %v", string(kftypes.VERBOSE), bindErr)
+		log.Errorf("Couldn't set flag --%v: %v", string(kftypes.VERBOSE), bindErr)
 		return
 	}
 
@@ -72,7 +72,7 @@ The flatten flag discards both registry and name components except for the last 
 			}
 
 			if info.IsDir() {
-				log.Debugf("looking for kustomization.yaml in %q\n", path)
+				log.Debugf("Looking for kustomization.yaml in %q\n", path)
 				absPath, err := filepath.Abs(path)
 				if err != nil {
 					return err

--- a/cmd/kfctl/cmd/show.go
+++ b/cmd/kfctl/cmd/show.go
@@ -65,7 +65,7 @@ func init() {
 		string(kftypes.VERBOSE)+" output default is false")
 	bindErr := showCfg.BindPFlag(string(kftypes.VERBOSE), showCmd.Flags().Lookup(string(kftypes.VERBOSE)))
 	if bindErr != nil {
-		log.Errorf("couldn't set flag --%v: %v", string(kftypes.VERBOSE), bindErr)
+		log.Errorf("Couldn't set flag --%v: %v", string(kftypes.VERBOSE), bindErr)
 		return
 	}
 }

--- a/pkg/apis/apps/group.go
+++ b/pkg/apis/apps/group.go
@@ -178,7 +178,7 @@ func LoadKfApp(name string, kfdef *kfdefs.KfDef) (KfApp, error) {
 	if err != nil {
 		return nil, &kfapis.KfError{
 			Code:    int(kfapis.INVALID_ARGUMENT),
-			Message: fmt.Sprintf("could not load plugin %v for platform %v Error %v", pluginpath, pluginname, err),
+			Message: fmt.Sprintf("could not load plugin %v for platform %v: %v", pluginpath, pluginname, err),
 		}
 	}
 	symName := "GetKfApp"
@@ -186,7 +186,7 @@ func LoadKfApp(name string, kfdef *kfdefs.KfDef) (KfApp, error) {
 	if symbolErr != nil {
 		return nil, &kfapis.KfError{
 			Code:    int(kfapis.INTERNAL_ERROR),
-			Message: fmt.Sprintf("could not find symbol %v for platform %v Error %v", symName, pluginname, symbolErr),
+			Message: fmt.Sprintf("could not find symbol %v for platform %v: %v", symName, pluginname, symbolErr),
 		}
 	}
 	return symbol.(func(*kfdefs.KfDef) KfApp)(kfdef), nil
@@ -201,7 +201,7 @@ func DownloadToCache(appDir string, repo string, version string) (string, error)
 	if _, err := os.Stat(appDir); os.IsNotExist(err) {
 		appdirErr := os.Mkdir(appDir, os.ModePerm)
 		if appdirErr != nil {
-			log.Errorf("couldn't create directory %v Error %v", appDir, appdirErr)
+			log.Errorf("couldn't create directory %v: %v", appDir, appdirErr)
 		}
 	}
 	cacheDir := path.Join(appDir, DefaultCacheDir)
@@ -214,7 +214,7 @@ func DownloadToCache(appDir string, repo string, version string) (string, error)
 	if cacheDirErr != nil {
 		return "", &kfapis.KfError{
 			Code:    int(kfapis.INVALID_ARGUMENT),
-			Message: fmt.Sprintf("couldn't create directory %v Error %v", cacheDir, cacheDirErr),
+			Message: fmt.Sprintf("couldn't create directory %v: %v", cacheDir, cacheDirErr),
 		}
 	}
 	// Version can be
@@ -231,14 +231,14 @@ func DownloadToCache(appDir string, repo string, version string) (string, error)
 	if tarballUrlErr != nil {
 		return "", &kfapis.KfError{
 			Code:    int(kfapis.INVALID_ARGUMENT),
-			Message: fmt.Sprintf("couldn't download kubeflow repo %v Error %v", tarballUrl, tarballUrlErr),
+			Message: fmt.Sprintf("couldn't download kubeflow repo %v: %v", tarballUrl, tarballUrlErr),
 		}
 	}
 	files, filesErr := ioutil.ReadDir(cacheDir)
 	if filesErr != nil {
 		return "", &kfapis.KfError{
 			Code:    int(kfapis.INVALID_ARGUMENT),
-			Message: fmt.Sprintf("couldn't read %v Error %v", cacheDir, filesErr),
+			Message: fmt.Sprintf("couldn't read %v: %v", cacheDir, filesErr),
 		}
 	}
 	subdir := files[0].Name()
@@ -253,7 +253,7 @@ func DownloadToCache(appDir string, repo string, version string) (string, error)
 			if versionPathErr != nil {
 				return "", &kfapis.KfError{
 					Code: int(kfapis.INTERNAL_ERROR),
-					Message: fmt.Sprintf("couldn't create directory %v Error %v",
+					Message: fmt.Sprintf("couldn't create directory %v: %v",
 						versionPath, versionPathErr),
 				}
 			}
@@ -263,7 +263,7 @@ func DownloadToCache(appDir string, repo string, version string) (string, error)
 	if renameErr != nil {
 		return "", &kfapis.KfError{
 			Code:    int(kfapis.INVALID_ARGUMENT),
-			Message: fmt.Sprintf("couldn't rename %v to %v Error %v", extractedPath, newPath, renameErr),
+			Message: fmt.Sprintf("couldn't rename %v to %v: %v", extractedPath, newPath, renameErr),
 		}
 	}
 	return newPath, nil
@@ -295,7 +295,7 @@ func GetConfig() *rest.Config {
 	overrides := &clientcmd.ConfigOverrides{}
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides).ClientConfig()
 	if err != nil {
-		log.Warnf("could not open %v Error %v", loadingRules.ExplicitPath, err)
+		log.Warnf("could not open %v: %v", loadingRules.ExplicitPath, err)
 		log.Infof("trying to load rest.config with inClusterConfig...")
 		config, err = rest.InClusterConfig()
 		if err != nil {

--- a/pkg/apis/apps/group.go
+++ b/pkg/apis/apps/group.go
@@ -201,7 +201,7 @@ func DownloadToCache(appDir string, repo string, version string) (string, error)
 	if _, err := os.Stat(appDir); os.IsNotExist(err) {
 		appdirErr := os.Mkdir(appDir, os.ModePerm)
 		if appdirErr != nil {
-			log.Errorf("couldn't create directory %v: %v", appDir, appdirErr)
+			log.Errorf("Couldn't create directory %v: %v", appDir, appdirErr)
 		}
 	}
 	cacheDir := path.Join(appDir, DefaultCacheDir)
@@ -295,11 +295,11 @@ func GetConfig() *rest.Config {
 	overrides := &clientcmd.ConfigOverrides{}
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides).ClientConfig()
 	if err != nil {
-		log.Warnf("could not open %v: %v", loadingRules.ExplicitPath, err)
-		log.Infof("trying to load rest.config with inClusterConfig...")
+		log.Warnf("Could not open %v: %v", loadingRules.ExplicitPath, err)
+		log.Infof("Trying to load rest.config with inClusterConfig...")
 		config, err = rest.InClusterConfig()
 		if err != nil {
-			log.Warnf("could not load rest.config with inClusterConfig and %v", loadingRules.ExplicitPath)
+			log.Warnf("Could not load rest.config with inClusterConfig and %v", loadingRules.ExplicitPath)
 		}
 	}
 	return config
@@ -309,7 +309,7 @@ func GetConfig() *rest.Config {
 func GetServerVersion(c *clientset.Clientset) string {
 	serverVersion, serverVersionErr := c.ServerVersion()
 	if serverVersionErr != nil {
-		log.Fatalf("couldn't get server version info. Error: %v", serverVersionErr)
+		log.Fatalf("Couldn't get server version info. Error: %v", serverVersionErr)
 	}
 	re := regexp.MustCompile("^v[0-9]+.[0-9]+.[0-9]+")
 	version := re.FindString(serverVersion.String())
@@ -321,7 +321,7 @@ func GetKubeConfig() *clientcmdapi.Config {
 	kubeconfig := KubeConfigPath()
 	config, configErr := clientcmd.LoadFromFile(kubeconfig)
 	if configErr != nil {
-		log.Warnf("could not load config Error: %v", configErr)
+		log.Warnf("Could not load config Error: %v", configErr)
 	}
 	return config
 }

--- a/pkg/apis/apps/kfconfig/types.go
+++ b/pkg/apis/apps/kfconfig/types.go
@@ -352,7 +352,7 @@ func (c *KfConfig) IsPluginFinished(pluginKind PluginKindType) bool {
 		if IsConditionNotFound(err) {
 			return false
 		}
-		log.Warnf("error when getting condition info: %v", err)
+		log.Warnf("Error when getting condition info: %v", err)
 		return false
 	}
 	return cond.Status == v1.ConditionTrue
@@ -376,7 +376,7 @@ func (c *KfConfig) IsPluginFailed(pluginKind PluginKindType) bool {
 		if IsConditionNotFound(err) {
 			return false
 		}
-		log.Warnf("error when getting condition info: %v", err)
+		log.Warnf("Error when getting condition info: %v", err)
 		return false
 	}
 	return cond.Status == v1.ConditionTrue
@@ -439,7 +439,7 @@ func (c *KfConfig) SyncCache() error {
 		log.Infof("Creating directory %v", baseCacheDir)
 		appdirErr := os.MkdirAll(baseCacheDir, os.ModePerm)
 		if appdirErr != nil {
-			log.Errorf("couldn't create directory %v: %v", baseCacheDir, appdirErr)
+			log.Errorf("Couldn't create directory %v: %v", baseCacheDir, appdirErr)
 			return appdirErr
 		}
 	}

--- a/pkg/apis/apps/kfconfig/types.go
+++ b/pkg/apis/apps/kfconfig/types.go
@@ -439,7 +439,7 @@ func (c *KfConfig) SyncCache() error {
 		log.Infof("Creating directory %v", baseCacheDir)
 		appdirErr := os.MkdirAll(baseCacheDir, os.ModePerm)
 		if appdirErr != nil {
-			log.Errorf("couldn't create directory %v Error %v", baseCacheDir, appdirErr)
+			log.Errorf("couldn't create directory %v: %v", baseCacheDir, appdirErr)
 			return appdirErr
 		}
 	}
@@ -489,7 +489,7 @@ func (c *KfConfig) SyncCache() error {
 		if tarballUrlErr != nil {
 			return &kfapis.KfError{
 				Code:    int(kfapis.INVALID_ARGUMENT),
-				Message: fmt.Sprintf("couldn't download URI %v Error %v", r.URI, tarballUrlErr),
+				Message: fmt.Sprintf("couldn't download URI %v: %v", r.URI, tarballUrlErr),
 			}
 		}
 

--- a/pkg/apis/apps/kfdef/v1alpha1/application_types.go
+++ b/pkg/apis/apps/kfdef/v1alpha1/application_types.go
@@ -436,7 +436,7 @@ func (d *KfDef) SyncCache() error {
 		log.Infof("Creating directory %v", baseCacheDir)
 		appdirErr := os.MkdirAll(baseCacheDir, os.ModePerm)
 		if appdirErr != nil {
-			log.Errorf("couldn't create directory %v Error %v", baseCacheDir, appdirErr)
+			log.Errorf("couldn't create directory %v: %v", baseCacheDir, appdirErr)
 			return appdirErr
 		}
 	}
@@ -478,7 +478,7 @@ func (d *KfDef) SyncCache() error {
 		if tarballUrlErr != nil {
 			return &kfapis.KfError{
 				Code:    int(kfapis.INVALID_ARGUMENT),
-				Message: fmt.Sprintf("couldn't download URI %v Error %v", r.Uri, tarballUrlErr),
+				Message: fmt.Sprintf("couldn't download URI %v: %v", r.Uri, tarballUrlErr),
 			}
 		}
 

--- a/pkg/apis/apps/kfdef/v1alpha1/application_types.go
+++ b/pkg/apis/apps/kfdef/v1alpha1/application_types.go
@@ -345,7 +345,7 @@ func LoadKFDefFromURI(configFile string) (*KfDef, error) {
 	log.Infof("Downloading %v to %v", configFile, appFile)
 	configFileUri, err := netUrl.Parse(configFile)
 	if err != nil {
-		log.Errorf("could not parse configFile url")
+		log.Errorf("Could not parse configFile url")
 	}
 	if isValidUrl(configFile) {
 		errGet := gogetter.GetFile(appFile, configFile)
@@ -436,7 +436,7 @@ func (d *KfDef) SyncCache() error {
 		log.Infof("Creating directory %v", baseCacheDir)
 		appdirErr := os.MkdirAll(baseCacheDir, os.ModePerm)
 		if appdirErr != nil {
-			log.Errorf("couldn't create directory %v: %v", baseCacheDir, appdirErr)
+			log.Errorf("Couldn't create directory %v: %v", baseCacheDir, appdirErr)
 			return appdirErr
 		}
 	}

--- a/pkg/controller/kfdef/kfdef_controller.go
+++ b/pkg/controller/kfdef/kfdef_controller.go
@@ -85,14 +85,14 @@ func watchKubeflowResources(c controller.Controller) error {
 		})
 		err := c.Watch(&source.Kind{Type: u}, &handler.EnqueueRequestsFromMapFunc{
 			ToRequests: handler.ToRequestsFunc(func(a handler.MapObject) []reconcile.Request {
-				log.Infof("watch a change for kfdef resource: %v.%v.", a.Meta.GetName(), a.Meta.GetNamespace())
+				log.Infof("Watch a change for kfdef resource: %v.%v.", a.Meta.GetName(), a.Meta.GetNamespace())
 				return []reconcile.Request{
 					{NamespacedName: kfdefSingletonNN},
 				}
 			}),
 		}, ownedResourcePredicates)
 		if err != nil {
-			log.Errorf("cannot create watch for resources %v %v/%v. Error: %v.", t.Kind, t.Group, t.Version, err)
+			log.Errorf("Cannot create watch for resources %v %v/%v: %v.", t.Kind, t.Group, t.Version, err)
 		}
 	}
 	return nil
@@ -109,7 +109,7 @@ var ownedResourcePredicates = predicate.Funcs{
 	},
 	DeleteFunc: func(e event.DeleteEvent) bool {
 		object, err := meta.Accessor(e.Object)
-		log.Infof("got delete event for %v.%v.", object.GetName(), object.GetNamespace())
+		log.Infof("Got delete event for %v.%v.", object.GetName(), object.GetNamespace())
 		if err != nil {
 			return false
 		}
@@ -161,7 +161,7 @@ func (r *ReconcileKfDef) Reconcile(request reconcile.Request) (reconcile.Result,
 	finalizers := sets.NewString(instance.GetFinalizers()...)
 	if deleted {
 		if !finalizers.Has(finalizer) {
-			log.Infof("kfdef deleted.")
+			log.Info("Kfdef deleted.")
 			return reconcile.Result{}, nil
 		}
 		log.Infof("Deleting kfdef.")
@@ -173,7 +173,7 @@ func (r *ReconcileKfDef) Reconcile(request reconcile.Request) (reconcile.Result,
 		for retryCount := 0; errors.IsConflict(finalizerError) && retryCount < finalizerMaxRetries; retryCount++ {
 			// Based on Istio operator at https://github.com/istio/istio/blob/master/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
 			// for finalizer removal errors workaround.
-			log.Infof("conflict during finalizer removal, retrying.")
+			log.Info("Conflict during finalizer removal, retrying.")
 			_ = r.client.Get(context.TODO(), request.NamespacedName, instance)
 			finalizers = sets.NewString(instance.GetFinalizers()...)
 			finalizers.Delete(finalizer)
@@ -181,7 +181,7 @@ func (r *ReconcileKfDef) Reconcile(request reconcile.Request) (reconcile.Result,
 			finalizerError = r.client.Update(context.TODO(), instance)
 		}
 		if finalizerError != nil {
-			log.Errorf("error removing finalizer. Error: %v.", finalizerError)
+			log.Errorf("Error removing finalizer: %v.", finalizerError)
 			return reconcile.Result{}, finalizerError
 		}
 		return reconcile.Result{}, err

--- a/pkg/kfapp/aws/aws.go
+++ b/pkg/kfapp/aws/aws.go
@@ -19,7 +19,6 @@ package aws
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/gogo/protobuf/proto"
 	"io"
 	"io/ioutil"
 	"math/rand"
@@ -29,6 +28,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/gogo/protobuf/proto"
 
 	"golang.org/x/crypto/bcrypt"
 
@@ -227,7 +228,7 @@ func copyFile(source string, dest string) error {
 	if err != nil {
 		return &kfapis.KfError{
 			Code:    int(kfapis.INVALID_ARGUMENT),
-			Message: fmt.Sprintf("cannot create dest file %v  Error %v", dest, err),
+			Message: fmt.Sprintf("cannot create dest file %v : %v", dest, err),
 		}
 	}
 	defer to.Close()
@@ -235,7 +236,7 @@ func copyFile(source string, dest string) error {
 	if err != nil {
 		return &kfapis.KfError{
 			Code:    int(kfapis.INTERNAL_ERROR),
-			Message: fmt.Sprintf("copy failed source %v dest %v Error %v", source, dest, err),
+			Message: fmt.Sprintf("copy failed source %v dest %v: %v", source, dest, err),
 		}
 	}
 
@@ -326,7 +327,7 @@ func (aws *Aws) generateInfraConfigs() error {
 		if copyErr != nil {
 			return &kfapis.KfError{
 				Code: copyErr.(*kfapis.KfError).Code,
-				Message: fmt.Sprintf("Could not copy %v to %v Error %v",
+				Message: fmt.Sprintf("Could not copy %v to %v: %v",
 					sourceFile, destFile, copyErr.(*kfapis.KfError).Message),
 			}
 		}
@@ -456,7 +457,7 @@ func (aws *Aws) Generate(resources kftypes.ResourceEnum) error {
 	if setAwsPluginDefaultsErr := aws.setAwsPluginDefaults(); setAwsPluginDefaultsErr != nil {
 		return &kfapis.KfError{
 			Code: setAwsPluginDefaultsErr.(*kfapis.KfError).Code,
-			Message: fmt.Sprintf("Set aws plugin defaults Error %v",
+			Message: fmt.Sprintf("set aws plugin defaults: %v",
 				setAwsPluginDefaultsErr.(*kfapis.KfError).Message),
 		}
 	}
@@ -685,7 +686,7 @@ func (aws *Aws) Apply(resources kftypes.ResourceEnum) error {
 	if err := aws.setAwsPluginDefaults(); err != nil {
 		return &kfapis.KfError{
 			Code: err.(*kfapis.KfError).Code,
-			Message: fmt.Sprintf("aws set aws plugin defaults Error %v",
+			Message: fmt.Sprintf("aws set aws plugin defaults: %v",
 				err.(*kfapis.KfError).Message),
 		}
 	}
@@ -791,7 +792,7 @@ func (aws *Aws) Delete(resources kftypes.ResourceEnum) error {
 	if setAwsPluginDefaultsErr != nil {
 		return &kfapis.KfError{
 			Code: setAwsPluginDefaultsErr.(*kfapis.KfError).Code,
-			Message: fmt.Sprintf("aws set aws plugin defaults Error %v",
+			Message: fmt.Sprintf("aws set aws plugin defaults: %v",
 				setAwsPluginDefaultsErr.(*kfapis.KfError).Message),
 		}
 	}

--- a/pkg/kfapp/coordinator/coordinator.go
+++ b/pkg/kfapp/coordinator/coordinator.go
@@ -75,7 +75,7 @@ func (coord *coordinator) getPackageManagers(kfdef *kfconfig.KfConfig) *map[stri
 	var packagemanagers = make(map[string]kftypesv3.KfApp)
 	_packagemanager, _packagemanagerErr := getPackageManager(kfdef)
 	if _packagemanagerErr != nil {
-		log.Fatalf("could not get packagemanager %v: %v **", kftypesv3.KUSTOMIZE, _packagemanagerErr)
+		log.Fatalf("Could not get packagemanager %v: %v **", kftypesv3.KUSTOMIZE, _packagemanagerErr)
 	}
 	if _packagemanager != nil {
 		packagemanagers[kftypesv3.KUSTOMIZE] = _packagemanager
@@ -213,7 +213,7 @@ func NewLoadKfAppFromURI(configFile string) (kftypesv3.KfApp, error) {
 	if platform != "" {
 		_platform, _platformErr := getPlatform(c.KfDef)
 		if _platformErr != nil {
-			log.Fatalf("could not get platform %v: %v **", platform, _platformErr)
+			log.Fatalf("Could not get platform %v: %v **", platform, _platformErr)
 			return nil, _platformErr
 		}
 		if _platform != nil {
@@ -222,7 +222,7 @@ func NewLoadKfAppFromURI(configFile string) (kftypesv3.KfApp, error) {
 	}
 	pkg, pkgErr := getPackageManager(c.KfDef)
 	if pkgErr != nil {
-		log.Fatalf("could not get package manager %v: %v **", kftypesv3.KUSTOMIZE, pkgErr)
+		log.Fatalf("Could not get package manager %v: %v **", kftypesv3.KUSTOMIZE, pkgErr)
 		return nil, pkgErr
 	}
 	if pkg != nil {
@@ -263,7 +263,7 @@ func CreateKfAppCfgFile(d *kfconfig.KfConfig) (string, error) {
 		log.Infof("Creating directory %v", d.Spec.AppDir)
 		appdirErr := os.MkdirAll(d.Spec.AppDir, os.ModePerm)
 		if appdirErr != nil {
-			log.Errorf("couldn't create directory %v: %v", d.Spec.AppDir, appdirErr)
+			log.Errorf("Couldn't create directory %v: %v", d.Spec.AppDir, appdirErr)
 			return "", appdirErr
 		}
 	} else {
@@ -273,7 +273,7 @@ func CreateKfAppCfgFile(d *kfconfig.KfConfig) (string, error) {
 	log.Infof("Writing KfDef to %v", d.Spec.ConfigFileName)
 	cfgFilePathErr := kfconfigloaders.WriteConfigToFile(*d)
 	if cfgFilePathErr != nil {
-		log.Errorf("failed to write config: %v", cfgFilePathErr)
+		log.Errorf("Failed to write config: %v", cfgFilePathErr)
 	}
 	return filepath.Join(d.Spec.AppDir, d.Spec.ConfigFileName), cfgFilePathErr
 }

--- a/pkg/kfapp/coordinator/coordinator.go
+++ b/pkg/kfapp/coordinator/coordinator.go
@@ -75,7 +75,7 @@ func (coord *coordinator) getPackageManagers(kfdef *kfconfig.KfConfig) *map[stri
 	var packagemanagers = make(map[string]kftypesv3.KfApp)
 	_packagemanager, _packagemanagerErr := getPackageManager(kfdef)
 	if _packagemanagerErr != nil {
-		log.Fatalf("could not get packagemanager %v Error %v **", kftypesv3.KUSTOMIZE, _packagemanagerErr)
+		log.Fatalf("could not get packagemanager %v: %v **", kftypesv3.KUSTOMIZE, _packagemanagerErr)
 	}
 	if _packagemanager != nil {
 		packagemanagers[kftypesv3.KUSTOMIZE] = _packagemanager
@@ -213,7 +213,7 @@ func NewLoadKfAppFromURI(configFile string) (kftypesv3.KfApp, error) {
 	if platform != "" {
 		_platform, _platformErr := getPlatform(c.KfDef)
 		if _platformErr != nil {
-			log.Fatalf("could not get platform %v Error %v **", platform, _platformErr)
+			log.Fatalf("could not get platform %v: %v **", platform, _platformErr)
 			return nil, _platformErr
 		}
 		if _platform != nil {
@@ -222,7 +222,7 @@ func NewLoadKfAppFromURI(configFile string) (kftypesv3.KfApp, error) {
 	}
 	pkg, pkgErr := getPackageManager(c.KfDef)
 	if pkgErr != nil {
-		log.Fatalf("could not get package manager %v Error %v **", kftypesv3.KUSTOMIZE, pkgErr)
+		log.Fatalf("could not get package manager %v: %v **", kftypesv3.KUSTOMIZE, pkgErr)
 		return nil, pkgErr
 	}
 	if pkg != nil {
@@ -263,7 +263,7 @@ func CreateKfAppCfgFile(d *kfconfig.KfConfig) (string, error) {
 		log.Infof("Creating directory %v", d.Spec.AppDir)
 		appdirErr := os.MkdirAll(d.Spec.AppDir, os.ModePerm)
 		if appdirErr != nil {
-			log.Errorf("couldn't create directory %v Error %v", d.Spec.AppDir, appdirErr)
+			log.Errorf("couldn't create directory %v: %v", d.Spec.AppDir, appdirErr)
 			return "", appdirErr
 		}
 	} else {

--- a/pkg/kfapp/gcp/gcp.go
+++ b/pkg/kfapp/gcp/gcp.go
@@ -881,7 +881,7 @@ func (gcp *Gcp) Apply(resources kftypesv3.ResourceEnum) error {
 	if updateDMErr != nil {
 		return &kfapis.KfError{
 			Code: updateDMErr.(*kfapis.KfError).Code,
-			Message: fmt.Sprintf("gcp apply could not update deployment manager Error %v",
+			Message: fmt.Sprintf("gcp apply could not update deployment manager: %v",
 				updateDMErr.(*kfapis.KfError).Message),
 		}
 	}
@@ -890,7 +890,7 @@ func (gcp *Gcp) Apply(resources kftypesv3.ResourceEnum) error {
 	if secretsErr != nil {
 		return &kfapis.KfError{
 			Code: secretsErr.(*kfapis.KfError).Code,
-			Message: fmt.Sprintf("gcp apply could not create secrets Error %v",
+			Message: fmt.Sprintf("gcp apply could not create secrets: %v",
 				secretsErr.(*kfapis.KfError).Message),
 		}
 	}
@@ -899,7 +899,7 @@ func (gcp *Gcp) Apply(resources kftypesv3.ResourceEnum) error {
 	if err = gcp.allowAdmineditUserSA(gcpAdminSa, gcpUserSa); err != nil {
 		return &kfapis.KfError{
 			Code: err.(*kfapis.KfError).Code,
-			Message: fmt.Sprintf("Fail to setup workload identity: Error %v",
+			Message: fmt.Sprintf("Fail to setup workload identity:: %v",
 				err.(*kfapis.KfError).Message),
 		}
 	}
@@ -911,7 +911,7 @@ func (gcp *Gcp) Apply(resources kftypesv3.ResourceEnum) error {
 	if err = gcp.setupWorkloadIdentity(gcp.kfDef.Namespace, kubeflowWorkloadIdentityMapping); err != nil {
 		return &kfapis.KfError{
 			Code: err.(*kfapis.KfError).Code,
-			Message: fmt.Sprintf("Fail to setup workload identity: Error %v",
+			Message: fmt.Sprintf("Fail to setup workload identity:: %v",
 				err.(*kfapis.KfError).Message),
 		}
 	}
@@ -921,7 +921,7 @@ func (gcp *Gcp) Apply(resources kftypesv3.ResourceEnum) error {
 	if err = gcp.setupWorkloadIdentity(gcp.getIstioNamespace(), istioWorkloadIdentityMapping); err != nil {
 		return &kfapis.KfError{
 			Code: err.(*kfapis.KfError).Code,
-			Message: fmt.Sprintf("Fail to setup workload identity: Error %v",
+			Message: fmt.Sprintf("Fail to setup workload identity:: %v",
 				err.(*kfapis.KfError).Message),
 		}
 	}
@@ -1139,7 +1139,7 @@ func (gcp *Gcp) copyFile(source string, dest string) error {
 	if err != nil {
 		return &kfapis.KfError{
 			Code:    int(kfapis.INVALID_ARGUMENT),
-			Message: fmt.Sprintf("cannot create dest file %v  Error %v", dest, err),
+			Message: fmt.Sprintf("cannot create dest file %v : %v", dest, err),
 		}
 	}
 	defer to.Close()
@@ -1147,7 +1147,7 @@ func (gcp *Gcp) copyFile(source string, dest string) error {
 	if err != nil {
 		return &kfapis.KfError{
 			Code:    int(kfapis.INTERNAL_ERROR),
-			Message: fmt.Sprintf("copy failed source %v dest %v Error %v", source, dest, err),
+			Message: fmt.Sprintf("copy failed source %v dest %v: %v", source, dest, err),
 		}
 	}
 
@@ -1399,7 +1399,7 @@ func (gcp *Gcp) generateDMConfigs() error {
 		if copyErr != nil {
 			return &kfapis.KfError{
 				Code: copyErr.(*kfapis.KfError).Code,
-				Message: fmt.Sprintf("could not copy %v to %v using repo local path %v Error %v",
+				Message: fmt.Sprintf("could not copy %v to %v using repo local path %v: %v",
 					sourceFile, destFile, repo.LocalPath, copyErr.(*kfapis.KfError).Message),
 			}
 		}
@@ -1812,7 +1812,7 @@ func (gcp *Gcp) SetupWorkloadIdentityPermission() error {
 	if err := gcp.setupWorkloadIdentity(gcp.kfDef.Namespace, kubeflowWorkloadIdentityMapping); err != nil {
 		return &kfapis.KfError{
 			Code: err.(*kfapis.KfError).Code,
-			Message: fmt.Sprintf("Fail to setup workload identity: Error %v",
+			Message: fmt.Sprintf("Fail to setup workload identity:: %v",
 				err.(*kfapis.KfError).Message),
 		}
 	}

--- a/pkg/kfapp/gcp/gcp.go
+++ b/pkg/kfapp/gcp/gcp.go
@@ -536,7 +536,7 @@ func bindAdmin(k8sClientset *clientset.Clientset, user string) error {
 		log.Infof("Updating default-admin...")
 		_, err = k8sClientset.RbacV1().ClusterRoleBindings().Update(binding)
 	} else {
-		log.Infof("default-admin not found, creating...")
+		log.Infof("Default-admin not found, creating...")
 		_, err = k8sClientset.RbacV1().ClusterRoleBindings().Create(binding)
 	}
 	if err == nil {
@@ -980,15 +980,15 @@ func (gcp *Gcp) deleteEndpoints(ctx context.Context) error {
 		}
 	}
 
-	log.Infof("deleting endpoint: %v", gcp.kfDef.Spec.Hostname)
+	log.Infof("Deleting endpoint: %v", gcp.kfDef.Spec.Hostname)
 	services := servicemanagement.NewServicesService(servicemanagementService)
 	op, deleteErr := services.Delete(gcp.kfDef.Spec.Hostname).Context(ctx).Do()
 	if deleteErr != nil {
-		log.Warningf("endpoint deletion error: %v", deleteErr)
+		log.Warningf("Endpoint deletion error: %v", deleteErr)
 		nextPage := ""
 		// Use a loop to read multi-page managed services list.
 		for {
-			log.Info("checking all endpoints...")
+			log.Info("Checking all endpoints...")
 			list := services.List().ProducerProjectId(gcp.kfDef.Spec.Project)
 			if nextPage != "" {
 				list = list.PageToken(nextPage)
@@ -1025,7 +1025,7 @@ func (gcp *Gcp) deleteEndpoints(ctx context.Context) error {
 	return backoff.Retry(func() error {
 		newOp, retryErr := opService.Get(opName).Context(ctx).Do()
 		if retryErr != nil {
-			log.Errorf("long running endpoint deletion error: %v", retryErr)
+			log.Errorf("Long running endpoint deletion error: %v", retryErr)
 			return &kfapis.KfError{
 				Code:    int(kfapis.INTERNAL_ERROR),
 				Message: fmt.Sprintf("long running endpoint deletion error: %v", retryErr),
@@ -1044,7 +1044,7 @@ func (gcp *Gcp) deleteEndpoints(ctx context.Context) error {
 					Message: fmt.Sprintf("Abnormal response code: %v", newOp.HTTPStatusCode),
 				})
 			}
-			log.Infof("endpoint deletion %v is completed: %v", gcp.kfDef.Spec.Hostname, string(newOp.Response))
+			log.Infof("Endpoint deletion %v is completed: %v", gcp.kfDef.Spec.Hostname, string(newOp.Response))
 			return nil
 		}
 		log.Infof("Endpoint deletion is running: %v (op = %v)", gcp.kfDef.Spec.Hostname, newOp.Name)
@@ -2053,40 +2053,40 @@ func (gcp *Gcp) setGcpPluginDefaults() error {
 	if gcp.kfDef.Spec.Email == "" && gcp.gcpAccountGetter != nil {
 		email, err := gcp.gcpAccountGetter()
 		if err != nil {
-			log.Errorf("cannot get gcloud account email. Error: %v", err)
+			log.Errorf("Cannot get gcloud account email. Error: %v", err)
 			return err
 		}
 		gcp.kfDef.Spec.Email = strings.TrimSpace(email)
 		pluginSpec.Email = strings.TrimSpace(email)
 		log.Infof("Setting Email to default: %v", gcp.kfDef.Spec.Email)
 	} else if gcp.kfDef.Spec.Email == "" {
-		log.Warnf("gcpAccountGetter not set; can't get default email")
+		log.Warnf("GcpAccountGetter not set; can't get default email")
 	}
 	// Set the project
 	if gcp.kfDef.Spec.Project == "" && gcp.gcpProjectGetter != nil {
 		project, err := gcp.gcpProjectGetter()
 		if err != nil {
-			log.Errorf("cannot get gcloud project. Error: %v", err)
+			log.Errorf("Cannot get gcloud project. Error: %v", err)
 			return err
 		}
 		gcp.kfDef.Spec.Project = strings.TrimSpace(project)
 		pluginSpec.Project = strings.TrimSpace(project)
 		log.Infof("Setting Project to default: %v", gcp.kfDef.Spec.Project)
 	} else if gcp.kfDef.Spec.Project == "" {
-		log.Warnf("gcpProjectGetter not set; can't get default project")
+		log.Warnf("GcpProjectGetter not set; can't get default project")
 	}
 	// Set the zone
 	if gcp.kfDef.Spec.Zone == "" && gcp.gcpZoneGetter != nil {
 		zone, err := gcp.gcpZoneGetter()
 		if err != nil {
-			log.Errorf("cannot get gcloud compute/zone. Error: %v", err)
+			log.Errorf("Cannot get gcloud compute/zone. Error: %v", err)
 			return err
 		}
 		gcp.kfDef.Spec.Zone = strings.TrimSpace(zone)
 		pluginSpec.Zone = strings.TrimSpace(zone)
 		log.Infof("Setting Zone to default: %v", gcp.kfDef.Spec.Zone)
 	} else if gcp.kfDef.Spec.Zone == "" {
-		log.Warnf("gcpZoneGetter not set; can't get default zone")
+		log.Warnf("GcpZoneGetter not set; can't get default zone")
 	}
 
 	return gcp.kfDef.SetPluginSpec(GcpPluginName, pluginSpec)
@@ -2098,7 +2098,7 @@ func (gcp *Gcp) Generate(resources kftypesv3.ResourceEnum) error {
 	gcpDir := path.Join(gcp.kfDef.Spec.AppDir, GCP_CONFIG)
 	if _, err := os.Stat(gcpDir); err == nil {
 		// Noop if the directory already exists.
-		log.Infof("folder %v exists, skip gcp.Generate", gcpDir)
+		log.Infof("Folder %v exists, skip gcp.Generate", gcpDir)
 		return nil
 	} else if !os.IsNotExist(err) {
 		log.Errorf("Stat folder %v error: %v; try deleting it...", gcpDir, err)
@@ -2283,7 +2283,7 @@ func (gcp *Gcp) gcpInitProject() error {
 	return backoff.Retry(func() error {
 		newOp, retryErr := opService.Get(opName).Context(ctx).Do()
 		if retryErr != nil {
-			log.Errorf("long running batch API enabling services error: %v", retryErr)
+			log.Errorf("Long running batch API enabling services error: %v", retryErr)
 			return &kfapis.KfError{
 				Code:    int(kfapis.INVALID_ARGUMENT),
 				Message: fmt.Sprintf("long running batch API enabling services error: %v", retryErr),
@@ -2302,11 +2302,11 @@ func (gcp *Gcp) gcpInitProject() error {
 					Message: fmt.Sprintf("Abnormal response code: %v", newOp.HTTPStatusCode),
 				})
 			}
-			log.Infof("batch API enabling is completed: %v", enabledApis)
+			log.Infof("Batch API enabling is completed: %v", enabledApis)
 			return nil
 
 		}
-		log.Infof("batch API enabling is running: %v (op = %v)", enabledApis, newOp.Name)
+		log.Infof("Batch API enabling is running: %v (op = %v)", enabledApis, newOp.Name)
 		opName = "" + newOp.Name
 		return &kfapis.KfError{
 			Code:    int(kfapis.INTERNAL_ERROR),

--- a/pkg/kfconfig/loaders/loaders.go
+++ b/pkg/kfconfig/loaders/loaders.go
@@ -71,7 +71,7 @@ func LoadConfigFromURI(configFile string) (*kfconfig.KfConfig, error) {
 		log.Infof("Downloading %v to %v", configFile, appFile)
 		configFileUri, err := netUrl.Parse(configFile)
 		if err != nil {
-			log.Errorf("could not parse configFile url")
+			log.Errorf("Could not parse configFile url")
 		}
 		if isValidUrl(configFile) {
 			errGet := gogetter.GetFile(appFile, configFile)

--- a/pkg/kfconfig/types.go
+++ b/pkg/kfconfig/types.go
@@ -363,7 +363,7 @@ func (c *KfConfig) IsPluginFinished(pluginKind PluginKindType) bool {
 		if IsConditionNotFound(err) {
 			return false
 		}
-		log.Warnf("error when getting condition info: %v", err)
+		log.Warnf("Error when getting condition info: %v", err)
 		return false
 	}
 	return cond.Status == v1.ConditionTrue
@@ -387,7 +387,7 @@ func (c *KfConfig) IsPluginFailed(pluginKind PluginKindType) bool {
 		if IsConditionNotFound(err) {
 			return false
 		}
-		log.Warnf("error when getting condition info: %v", err)
+		log.Warnf("Error when getting condition info: %v", err)
 		return false
 	}
 	return cond.Status == v1.ConditionTrue
@@ -450,7 +450,7 @@ func (c *KfConfig) SyncCache() error {
 		log.Infof("Creating directory %v", baseCacheDir)
 		appdirErr := os.MkdirAll(baseCacheDir, os.ModePerm)
 		if appdirErr != nil {
-			log.Errorf("couldn't create directory %v: %v", baseCacheDir, appdirErr)
+			log.Errorf("Couldn't create directory %v: %v", baseCacheDir, appdirErr)
 			return appdirErr
 		}
 	}
@@ -551,10 +551,10 @@ func (c *KfConfig) SyncCache() error {
 		if u.Scheme == "http" || u.Scheme == "https" {
 			subdir := files[0].Name()
 			localPath = path.Join(cacheDir, subdir)
-			log.Infof("updating localPath to %v", localPath)
+			log.Infof("Updating localPath to %v", localPath)
 		} else if u.Scheme == "file" {
 			filePath := strings.TrimPrefix(r.URI, "file:")
-			log.Infof("probing file path: %v", filePath)
+			log.Infof("Probing file path: %v", filePath)
 			if fileInfo, err := os.Stat(filePath); err != nil {
 				return &kfapis.KfError{
 					Code:    int(kfapis.INVALID_ARGUMENT),
@@ -563,7 +563,7 @@ func (c *KfConfig) SyncCache() error {
 			} else if !fileInfo.IsDir() {
 				subdir := files[0].Name()
 				localPath = path.Join(cacheDir, subdir)
-				log.Infof("updating localPath to %v", localPath)
+				log.Infof("Updating localPath to %v", localPath)
 			}
 		}
 

--- a/pkg/kfconfig/types.go
+++ b/pkg/kfconfig/types.go
@@ -450,7 +450,7 @@ func (c *KfConfig) SyncCache() error {
 		log.Infof("Creating directory %v", baseCacheDir)
 		appdirErr := os.MkdirAll(baseCacheDir, os.ModePerm)
 		if appdirErr != nil {
-			log.Errorf("couldn't create directory %v Error %v", baseCacheDir, appdirErr)
+			log.Errorf("couldn't create directory %v: %v", baseCacheDir, appdirErr)
 			return appdirErr
 		}
 	}
@@ -524,7 +524,7 @@ func (c *KfConfig) SyncCache() error {
 			if err != nil {
 				return &kfapis.KfError{
 					Code:    int(kfapis.INVALID_ARGUMENT),
-					Message: fmt.Sprintf("couldn't download URI %v Error %v", r.URI, err),
+					Message: fmt.Sprintf("couldn't download URI %v: %v", r.URI, err),
 				}
 			}
 			defer resp.Body.Close()

--- a/pkg/kfupgrade/kfupgrade.go
+++ b/pkg/kfupgrade/kfupgrade.go
@@ -91,7 +91,7 @@ func createNewKfApp(baseConfig string, version string, oldKfCfg *kfconfig.KfConf
 		log.Infof("Creating directory %v", newAppDir)
 		err = os.MkdirAll(newAppDir, os.ModePerm)
 		if err != nil {
-			log.Errorf("couldn't create directory %v: %v", newAppDir, err)
+			log.Errorf("Couldn't create directory %v: %v", newAppDir, err)
 			return nil, "", err
 		}
 	} else {

--- a/pkg/kfupgrade/kfupgrade.go
+++ b/pkg/kfupgrade/kfupgrade.go
@@ -91,7 +91,7 @@ func createNewKfApp(baseConfig string, version string, oldKfCfg *kfconfig.KfConf
 		log.Infof("Creating directory %v", newAppDir)
 		err = os.MkdirAll(newAppDir, os.ModePerm)
 		if err != nil {
-			log.Errorf("couldn't create directory %v Error %v", newAppDir, err)
+			log.Errorf("couldn't create directory %v: %v", newAppDir, err)
 			return nil, "", err
 		}
 	} else {

--- a/pkg/mirror/mirror_image.go
+++ b/pkg/mirror/mirror_image.go
@@ -124,7 +124,7 @@ func generateCloudBuild(rt ReplicateTasks) error {
 	images := []string{}
 	for _, newImg := range rt.orderedKeys() {
 		oldImg := rt[newImg]
-		log.Infof("add gcb step" + oldImg)
+		log.Infof("Add gcb step" + oldImg)
 		steps = append(steps,
 			&cloudbuild.BuildStep{
 				Name:    CLOUD_BUILD_IMAGE,
@@ -171,17 +171,17 @@ func (rt *ReplicateTasks) fillTasks(registry string, buildContext string, includ
 						curName = image.NewName
 					}
 					if strings.Contains(curName, "$") {
-						log.Infof("image name %v contains kutomize parameter, skipping\n", curName)
+						log.Infof("Image name %v contains kutomize parameter, skipping\n", curName)
 						continue
 					}
 					// check exclude first
 					if strings.HasPrefix(curName, exclude) {
-						log.Infof("image %v matches exclude prefix %v, skipping\n", curName, exclude)
+						log.Infof("Image %v matches exclude prefix %v, skipping\n", curName, exclude)
 						continue
 					}
 					// then check include
 					if include != "" && (!strings.HasPrefix(curName, include)) {
-						log.Infof("image %v doesn't match include prefix %v, skipping\n", curName, include)
+						log.Infof("Image %v doesn't match include prefix %v, skipping\n", curName, include)
 						continue
 					}
 					newName := strings.Join([]string{registry, image.Name}, "/")
@@ -254,7 +254,7 @@ func UpdateKustomize(inputFile string) error {
 			}
 		}
 		imageMapping[oldImg] = newImg
-		log.Infof("updating image %v to %v", oldImg, newImg)
+		log.Infof("Updating image %v to %v", oldImg, newImg)
 	}
 
 	return filepath.Walk(KUSTOMIZE_FOLDER, func(path string, info os.FileInfo, err error) error {

--- a/pkg/mirror/mirror_image_test.go
+++ b/pkg/mirror/mirror_image_test.go
@@ -18,7 +18,7 @@ type testCase struct {
 
 func init() {
 	if err := os.Chdir("testdata"); err != nil {
-		log.Errorf("failed to change dir %v", err)
+		log.Errorf("Failed to change dir %v", err)
 	}
 }
 

--- a/pkg/utils/awsutil.go
+++ b/pkg/utils/awsutil.go
@@ -18,9 +18,10 @@ package utils
 
 import (
 	"fmt"
-	awssdk "github.com/aws/aws-sdk-go/aws"
 	"os/exec"
 	"regexp"
+
+	awssdk "github.com/aws/aws-sdk-go/aws"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -76,6 +77,7 @@ func GetEksctlVersion() (string, error) {
 		return "", err
 	}
 
+	log.Infof("Output: %s", output)
 	// [ℹ]  version.Info{BuiltAt:"", GitCommit:"", GitTag:"0.1.32"}
 	r := regexp.MustCompile("[0-9]+.[0-9]+.[0-9]+")
 	matchGroups := r.FindStringSubmatch(string(output))

--- a/pkg/utils/k8utils.go
+++ b/pkg/utils/k8utils.go
@@ -123,7 +123,7 @@ func CreateResourceFromFile(config *rest.Config, filename string, elems ...confi
 
 		err := c.Get(context.TODO(), k8stypes.NamespacedName{Name: name, Namespace: namespace}, u.DeepCopy())
 		if err == nil {
-			log.Info("object already exists...")
+			log.Info("Object already exists...")
 			continue
 		}
 		if !k8serrors.IsNotFound(err) {
@@ -235,7 +235,7 @@ func DeleteResourceFromFile(config *rest.Config, filename string) error {
 
 		err := c.Get(context.TODO(), k8stypes.NamespacedName{Name: name, Namespace: namespace}, u.DeepCopy())
 		if k8serrors.IsNotFound(err) {
-			log.Info("object already deleted...")
+			log.Info("Object already deleted...")
 			continue
 		}
 		if err != nil {

--- a/pkg/utils/k8utils.go
+++ b/pkg/utils/k8utils.go
@@ -278,7 +278,7 @@ func NewApply(namespace string, restConfig *rest.Config) (*Apply, error) {
 	if err != nil {
 		return nil, &kfapis.KfError{
 			Code:    int(kfapis.INTERNAL_ERROR),
-			Message: fmt.Sprintf("could not get clientset Error %v", err),
+			Message: fmt.Sprintf("could not get clientset: %v", err),
 		}
 	}
 	apply.clientset = clientset
@@ -315,7 +315,7 @@ func (a *Apply) Apply(data []byte) error {
 	if initializeErr != nil {
 		return &kfapis.KfError{
 			Code:    int(kfapis.INTERNAL_ERROR),
-			Message: fmt.Sprintf("could not initialize  Error %v", initializeErr),
+			Message: fmt.Sprintf("could not initialize : %v", initializeErr),
 		}
 	}
 	var err error
@@ -338,7 +338,7 @@ func (a *Apply) run() error {
 	if resourcesErr != nil {
 		return &kfapis.KfError{
 			Code:    int(kfapis.INTERNAL_ERROR),
-			Message: fmt.Sprintf("Apply.Run  Error %v", resourcesErr),
+			Message: fmt.Sprintf("Apply.Run : %v", resourcesErr),
 		}
 	}
 	return nil


### PR DESCRIPTION
My main goal here was just surfacing the error here: https://github.com/kubeflow/kfctl/pull/264/files#diff-85e9677c1c2a51f1c1d287363401b6a7R438

But since I've been at it, I've also tried to improve the error formatting/logging in general:

- Uppercase log entries
- Lowercase errors
- Always add err to returned err
- Replace " Error " prefix by ": " to be consistend and more go
  idiomatic

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/264)
<!-- Reviewable:end -->
