### PR TITLE
Create OIDC secret and pass to alb-ingress-controller

### DIFF
--- a/pkg/kfapp/aws/k8sClient.go
+++ b/pkg/kfapp/aws/k8sClient.go
@@ -82,6 +82,7 @@ func createSecret(client *clientset.Clientset, secretName string, namespace stri
 		},
 		Data: data,
 	}
+	log.Infof("Creating secret: %v/%v", namespace, secretName)
 	_, err := client.CoreV1().Secrets(namespace).Create(secret)
 	if err == nil {
 		return nil


### PR DESCRIPTION
1. Remove cognito and add oidc overlay to istio-ingress applications
2. Create a secret using clientId and clientSecret and pass to alb

Signed-off-by: Jiaxin Shan <seedjeffwan@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/267)
<!-- Reviewable:end -->
