### PR TITLE
Create Istio-system namespace before create OIDC secret

### DIFF
--- a/pkg/kfapp/aws/aws.go
+++ b/pkg/kfapp/aws/aws.go
@@ -722,6 +722,13 @@ func (aws *Aws) Apply(resources kftypes.ResourceEnum) error {
 		}
 	}
 
+	if err := createNamespace(aws.k8sClient, IstioNamespace); err != nil {
+		return &kfapis.KfError{
+			Code:    int(kfapis.INTERNAL_ERROR),
+			Message: fmt.Sprintf("Could not create namespace %v", err),
+		}
+	}
+
 	// Create IAM role binding for k8s service account.
 	if awsPluginSpec.GetEnablePodIamPolicy() && isEksCluster {
 		err := aws.setupIamRoleForServiceAccount()


### PR DESCRIPTION
## Issue to solve
We need to create namespace `istio-system` before we create OIDC secret since OIDC secret is created under the namespace of `istio-system`.

## Changes 
Create namespace `IstioNamespace` prior to create OIDC secret. 

## Test
After merged, will test on `kfctl_aws.1.0.0.yaml` and `kfctl_aws_cognito.1.0.0.yaml` for setting up kubeflow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/273)
<!-- Reviewable:end -->
