### PR TITLE
Create iap resources only when kfdef contains iap-ingress

### DIFF
--- a/pkg/kfapp/gcp/gcp.go
+++ b/pkg/kfapp/gcp/gcp.go
@@ -1993,9 +1993,11 @@ func (gcp *Gcp) setGcpPluginDefaults() error {
 
 			pluginSpec.Auth.IAP.OAuthClientId = os.Getenv(CLIENT_ID)
 
-			if pluginSpec.Auth.IAP.OAuthClientId == "" {
-				log.Errorf("Could not configure IAP auth; environment variable %s not set", CLIENT_ID)
-				return errors.WithStack(fmt.Errorf("Could not configure IAP auth; environment variable %s not set", CLIENT_ID))
+			if pluginSpec.Auth.IAP.OAuthClientId == "" || os.Getenv(CLIENT_SECRET) == ""{
+				log.Errorf("Could not configure IAP auth; environment variable %s or %s not set", CLIENT_ID,
+					CLIENT_SECRET)
+				return errors.WithStack(fmt.Errorf("Could not configure IAP auth; environment variable %s or %s not set",
+					CLIENT_ID, CLIENT_SECRET))
 			}
 
 			pluginSpec.Auth.IAP.OAuthClientSecret = &kfconfig.SecretRef{

--- a/pkg/kfapp/gcp/gcp.go
+++ b/pkg/kfapp/gcp/gcp.go
@@ -1992,12 +1992,13 @@ func (gcp *Gcp) setGcpPluginDefaults() error {
 			pluginSpec.Auth.IAP = &gcpplugin.IAP{}
 
 			pluginSpec.Auth.IAP.OAuthClientId = os.Getenv(CLIENT_ID)
+			if os.Getenv(CLIENT_SECRET) == "" {
+				log.Warnf("Could not configure IAP auth; environment variable %s not set", CLIENT_SECRET)
+			}
 
-			if pluginSpec.Auth.IAP.OAuthClientId == "" || os.Getenv(CLIENT_SECRET) == ""{
-				log.Errorf("Could not configure IAP auth; environment variable %s or %s not set", CLIENT_ID,
-					CLIENT_SECRET)
-				return errors.WithStack(fmt.Errorf("Could not configure IAP auth; environment variable %s or %s not set",
-					CLIENT_ID, CLIENT_SECRET))
+			if pluginSpec.Auth.IAP.OAuthClientId == "" {
+				log.Errorf("Could not configure IAP auth; environment variable %s not set", CLIENT_ID)
+				return errors.WithStack(fmt.Errorf("Could not configure IAP auth; environment variable %s not set", CLIENT_ID))
 			}
 
 			pluginSpec.Auth.IAP.OAuthClientSecret = &kfconfig.SecretRef{

--- a/pkg/kfapp/gcp/gcp_test.go
+++ b/pkg/kfapp/gcp/gcp_test.go
@@ -2,7 +2,6 @@ package gcp
 
 import (
 	"encoding/json"
-
 	"github.com/gogo/protobuf/proto"
 	kftypes "github.com/kubeflow/kfctl/v3/pkg/apis/apps"
 	"github.com/kubeflow/kfctl/v3/pkg/kfconfig"
@@ -12,7 +11,7 @@ import (
 	"reflect"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -157,6 +156,11 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 			Name: "no-plugin-iap",
 			Input: &kfconfig.KfConfig{
 				Spec: kfconfig.KfConfigSpec{
+					Applications: []kfconfig.Application {
+						{
+							Name: IAP_INGRESS,
+						},
+					},
 					UseBasicAuth: false,
 				},
 			},
@@ -186,6 +190,11 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 			Name: "set-email",
 			Input: &kfconfig.KfConfig{
 				Spec: kfconfig.KfConfigSpec{
+					Applications: []kfconfig.Application {
+						{
+							Name: IAP_INGRESS,
+						},
+					},
 					UseBasicAuth: false,
 				},
 			},
@@ -231,6 +240,11 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 			Name: "trim-email",
 			Input: &kfconfig.KfConfig{
 				Spec: kfconfig.KfConfigSpec{
+					Applications: []kfconfig.Application {
+						{
+							Name: IAP_INGRESS,
+						},
+					},
 					UseBasicAuth: false,
 				},
 			},

--- a/pkg/kfapp/gcp/gcp_test.go
+++ b/pkg/kfapp/gcp/gcp_test.go
@@ -156,7 +156,7 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 			Name: "no-plugin-iap",
 			Input: &kfconfig.KfConfig{
 				Spec: kfconfig.KfConfigSpec{
-					Applications: []kfconfig.Application {
+					Applications: []kfconfig.Application{
 						{
 							Name: IAP_INGRESS,
 						},
@@ -190,7 +190,7 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 			Name: "set-email",
 			Input: &kfconfig.KfConfig{
 				Spec: kfconfig.KfConfigSpec{
-					Applications: []kfconfig.Application {
+					Applications: []kfconfig.Application{
 						{
 							Name: IAP_INGRESS,
 						},
@@ -240,7 +240,7 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 			Name: "trim-email",
 			Input: &kfconfig.KfConfig{
 				Spec: kfconfig.KfConfigSpec{
-					Applications: []kfconfig.Application {
+					Applications: []kfconfig.Application{
 						{
 							Name: IAP_INGRESS,
 						},
@@ -281,6 +281,11 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 			Name: "no-override",
 			Input: &kfconfig.KfConfig{
 				Spec: kfconfig.KfConfigSpec{
+					Applications: []kfconfig.Application{
+						{
+							Name: IAP_INGRESS,
+						},
+					},
 					UseBasicAuth: false,
 				},
 			},


### PR DESCRIPTION
Currently kfctl create IAP resources by default and will throw error when `CLIENT_ID` not set.
User actually might customize kfdef and use private ingress.

This change makes kfctl creating iap resources only when kfdef contains iap-ingress

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/277)
<!-- Reviewable:end -->
