### PR TITLE
Find User Default Region and Cred Setting

### DIFF
--- a/pkg/kfapp/aws/aws.go
+++ b/pkg/kfapp/aws/aws.go
@@ -134,7 +134,10 @@ func GetPlatform(kfdef *kfconfig.KfConfig) (kftypes.Platform, error) {
 		},
 	}
 
-	session := session.Must(session.NewSession())
+	// set aws.sess with shared config file information, such as region
+	session := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
 
 	k8sClient, err := getK8sclient()
 	if err != nil {


### PR DESCRIPTION
## Issue to solve
The issue is found in the kubeflow repo [here](https://github.com/kubeflow/kubeflow/issues/4854), the situation is that user use `kfctl apply kfctl_aws.yaml` can't find their plugin default settings.

## Changes we make
Rewrite `IsEksCluster` function to take default plugin settings without setting `AWS_REGION` manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/282)
<!-- Reviewable:end -->
