### PR TITLE
kfctl should support using kustomize to compose a stack of applications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,12 @@ build-kfctl: deepcopy generate fmt vet
 	GOOS=linux GOARCH=amd64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/linux/kfctl cmd/kfctl/main.go
 	cp bin/$(ARCH)/kfctl bin/kfctl
 
+# Fast rebuilds useful for development.
+# Does not regenerate code; assumes you already ran build-kfctl once.
+build-kfctl-fast: fmt vet
+	GOOS=linux GOARCH=amd64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/linux/kfctl cmd/kfctl/main.go
+	cp bin/$(ARCH)/kfctl bin/kfctl
+
 # Release tarballs suitable for upload to GitHub release pages
 build-kfctl-tgz: build-kfctl
 	chmod a+rx ./bin/kfctl

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 	gopkg.in/yaml.v2 v2.2.8
+	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.17.0
 	k8s.io/apiextensions-apiserver v0.0.0
 	k8s.io/apimachinery v0.17.1

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	k8s.io/kubernetes v1.16.2
 	k8s.io/utils v0.0.0-20191030222137-2b95a09bc58d // indirect
 	sigs.k8s.io/controller-runtime v0.4.0
+	sigs.k8s.io/kustomize v2.0.3+incompatible
 	sigs.k8s.io/kustomize/v3 v3.2.0
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1086,6 +1086,7 @@ gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/kfapp/gcp/gcp.go
+++ b/pkg/kfapp/gcp/gcp.go
@@ -2197,6 +2197,13 @@ func (gcp *Gcp) Generate(resources kftypesv3.ResourceEnum) error {
 		if err := gcp.kfDef.SetApplicationParameter("iap-ingress", "hostname", gcp.kfDef.Spec.Hostname); err != nil {
 			return errors.WithStack(err)
 		}
+		if err := gcp.kfDef.SetApplicationParameter("iap-ingress", "project", gcp.kfDef.Spec.Project); err != nil {
+			return errors.WithStack(err)
+		}
+		// appName is used to give a unique name to the cloud endpoint.
+		if err := gcp.kfDef.SetApplicationParameter("iap-ingress", "appName", gcp.kfDef.Name); err != nil {
+			return errors.WithStack(err)
+		}
 	}
 	if *pluginSpec.CreatePipelinePersistentStorage {
 		log.Infof("Configuring pipeline, minio, and mysql applications")

--- a/pkg/kfapp/gcp/gcp.go
+++ b/pkg/kfapp/gcp/gcp.go
@@ -96,6 +96,8 @@ const (
 	BasicAuthPasswordSecretName = "password"
 	// The PodDefault in default namespace
 	PodDefaultName = "add-gcp-secret"
+
+	DefaultIstioNamespace = "istio-system"
 )
 
 // Gcp implements KfApp Interface
@@ -1641,6 +1643,13 @@ func (gcp *Gcp) createBasicAuthSecret(client *clientset.Clientset) error {
 }
 
 func (gcp *Gcp) getIstioNamespace() string {
+	if gcp.kfDef.UsingStacks() {
+		// TODO(jlewi): With stacks we currently assume the iap-ingress is installed in istio-namespace.
+		// The namespace would now be set inside the kustomization.yaml file of the package. So if needed we
+		// could read the value from there.
+		log.Warnf("Assuming iap-ingress is installed in namespace: %v", DefaultIstioNamespace)
+		return DefaultIstioNamespace
+	}
 	if ingressNamespace, ok := gcp.kfDef.GetApplicationParameter("iap-ingress", "namespace"); ok {
 		return ingressNamespace
 	}

--- a/pkg/kfapp/kustomize/kustomize.go
+++ b/pkg/kfapp/kustomize/kustomize.go
@@ -409,9 +409,14 @@ func (kustomize *kustomize) Generate(resources kftypesv3.ResourceEnum) error {
 		kustomizeDir := path.Join(kustomize.kfDef.Spec.AppDir, outputDir)
 
 		if _, err := os.Stat(kustomizeDir); err == nil {
-			// Noop if the directory already exists.
-			log.Infof("folder %v exists, skip kustomize.Generate", kustomizeDir)
-			return nil
+			// When using the new stacks code the directory might already exist because it could have
+			// been created by calls to SetApplicationParameter. For the legacy code path (no stacks) we preserve
+			// the existing code path of not rerunning generate if the directory already exists.
+			if !kustomize.kfDef.UsingStacks() {
+				// Noop if the directory already exists.
+				log.Infof("folder %v exists, skip kustomize.Generate", kustomizeDir)
+				return nil
+			}
 		} else if !os.IsNotExist(err) {
 			log.Errorf("Stat folder %v error: %v; try deleting it...", kustomizeDir, err)
 			_ = os.RemoveAll(kustomizeDir)
@@ -440,10 +445,8 @@ func (kustomize *kustomize) Generate(resources kftypesv3.ResourceEnum) error {
 			return errors.WithStack(fmt.Errorf("Repo %v not listed in KfDef.Status; ", kftypesv3.ManifestsRepoName))
 		}
 
-		// if err := kustomize.initComponentMaps(); err != nil {
-		// 	log.Errorf("Could not initialize kustomize component map paths; error %v", err)
-		// 	return errors.WithStack(err)
-		// }
+		// determine whether we are using the new pattern of using kustomize to build stacks.
+		// hasStack := kustomize.kfDef.UsingStacks()
 
 		for _, app := range kustomize.kfDef.Spec.Applications {
 			log.Infof("Processing application: %v", app.Name)
@@ -470,18 +473,31 @@ func (kustomize *kustomize) Generate(resources kftypesv3.ResourceEnum) error {
 
 			appPath := path.Join(repoCache.LocalPath, app.KustomizeConfig.RepoRef.Path)
 
-			// Copy the component to kustomizeDir
-			if err := copy.Copy(appPath, path.Join(kustomizeDir, app.Name)); err != nil {
-				return &kfapisv3.KfError{
-					Code:    int(kfapisv3.INTERNAL_ERROR),
-					Message: fmt.Sprintf("couldn't copy application %s", app.Name),
+			if kustomize.kfDef.UsingStacks() {
+				// We handle generating the kustomize dir for application stacks differently.
+				stackAppDir := path.Join(kustomizeDir, app.Name)
+
+				// Path to the stack inside the cache.
+				stacksCacheDir := filepath.Join("../..", appPath)
+				if _, err := createStackAppKustomization(stackAppDir, stacksCacheDir); err != nil {
+					return errors.WithStack(fmt.Errorf("There was a problem building the kustomize app for the Kubeflow application stack; %v ", err))
 				}
-			}
-			if err := GenerateKustomizationFile(kustomize.kfDef, kustomizeDir, app.Name,
-				app.KustomizeConfig.Overlays, app.KustomizeConfig.Parameters); err != nil {
-				return &kfapisv3.KfError{
-					Code:    int(kfapisv3.INTERNAL_ERROR),
-					Message: fmt.Sprintf("couldn't generate kustomization file for component %s", app.Name),
+			} else {
+				// TODO(jlewi): This code path should eventually go away once we are fully migrated to the use
+				// of stacks.
+				// Copy the component to kustomizeDir
+				if err := copy.Copy(appPath, path.Join(kustomizeDir, app.Name)); err != nil {
+					return &kfapisv3.KfError{
+						Code:    int(kfapisv3.INTERNAL_ERROR),
+						Message: fmt.Sprintf("couldn't copy application %s", app.Name),
+					}
+				}
+				if err := GenerateKustomizationFile(kustomize.kfDef, kustomizeDir, app.Name,
+					app.KustomizeConfig.Overlays, app.KustomizeConfig.Parameters); err != nil {
+					return &kfapisv3.KfError{
+						Code:    int(kfapisv3.INTERNAL_ERROR),
+						Message: fmt.Sprintf("couldn't generate kustomization file for component %s", app.Name),
+					}
 				}
 			}
 		}
@@ -499,6 +515,80 @@ func (kustomize *kustomize) Generate(resources kftypesv3.ResourceEnum) error {
 		}
 	}
 	return nil
+}
+
+// createStackAppKustomization generates a kustomization.yaml file suitable for the kubeflow application stack.
+// stackAppDir is the directory to create for the kustomize package.
+// basePath is the path to the kustomize package to use as the base package.
+//
+// Returns the path to the kusotmizationFile.
+//
+// If the kustomization.yaml already exists then the changes are merged in.
+func createStackAppKustomization(stackAppDir string, basePath string) (string, error) {
+	kustomizationFile := filepath.Join(stackAppDir, kftypesv3.KustomizationFile)
+
+	if _, err := os.Stat(stackAppDir); err == nil {
+		// Noop if the directory already exists.
+		log.Infof("folder %v exists", stackAppDir)
+	} else if os.IsNotExist(err) {
+		log.Infof("Creating folder %v", stackAppDir)
+		if stackAppDirErr := os.MkdirAll(stackAppDir, os.ModePerm); stackAppDirErr != nil {
+			return "", &kfapisv3.KfError{
+				Code:    int(kfapisv3.INVALID_ARGUMENT),
+				Message: fmt.Sprintf("couldn't create directory %v Error %v", stackAppDir, stackAppDirErr),
+			}
+		}
+	} else {
+		return "", errors.WithStack(errors.Wrapf(err, "Unexpected error trying to access directory: %v", stackAppDir))
+	}
+
+	kustomization := &types.Kustomization{}
+
+	contents, err := ioutil.ReadFile(kustomizationFile)
+
+	// The kustomization file may not exist yet in which case we keep going because we will just create it.
+	if err == nil {
+		if err := yaml.Unmarshal(contents, kustomization); err != nil {
+			return "", errors.WithStack(errors.Wrapf(err, "Failed to unmashal %v", kustomizationFile))
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return "", errors.WithStack(errors.Wrapf(err, "Failed to read: %v", kustomizationFile))
+	}
+
+	// Create the kustomization file for the stack directory.
+	kustomization.TypeMeta = types.TypeMeta{
+		Kind:       "Kustomization",
+		APIVersion: "kustomize.config.k8s.io/v1beta1",
+	}
+
+	kustomization.Namespace = "kubeflow"
+
+	hasBasePath := false
+	for _, r := range kustomization.Resources {
+		if string(r) == basePath {
+			hasBasePath = true
+			break
+		}
+	}
+
+	if !hasBasePath {
+		kustomization.Resources = append(kustomization.Resources, basePath)
+	}
+	yaml, err := yaml.Marshal(kustomization)
+
+	if err != nil {
+		return "", errors.WithStack(errors.Wrapf(err, "Error trying to marshal kustomization for kubeflow apps stack:"))
+	}
+
+	kustomizationFileErr := ioutil.WriteFile(kustomizationFile, yaml, 0644)
+	if kustomizationFileErr != nil {
+		return "", &kfapisv3.KfError{
+			Code:    int(kfapisv3.INTERNAL_ERROR),
+			Message: fmt.Sprintf("error writing to %v Error %v", kustomizationFile, kustomizationFileErr),
+		}
+	}
+
+	return kustomizationFile, nil
 }
 
 // Init is called from 'kfctl init ...' and creates a <deployment> directory with an app.yaml file that
@@ -1070,7 +1160,10 @@ func GenerateKustomizationFile(kfDef *kfconfig.KfConfig, root string,
 // EvaluateKustomizeManifest evaluates the kustomize dir compDir, and returns the resources.
 func EvaluateKustomizeManifest(compDir string) (resmap.ResMap, error) {
 	fsys := fs.MakeRealFS()
-	lrc := loader.RestrictionRootOnly
+	// We don't enforce the security check because our kustomize packages are such that kustomization.yaml
+	// files may refer to patches and resources that are not in the current directory or below them.
+	// See http://bit.ly/kf_kustomize_v3
+	lrc := loader.RestrictionNone
 	ldr, err := loader.NewLoader(lrc, validators.MakeFakeValidator(), compDir, fsys)
 	if err != nil {
 		return nil, err

--- a/pkg/kfapp/kustomize/kustomize.go
+++ b/pkg/kfapp/kustomize/kustomize.go
@@ -556,12 +556,12 @@ func createStackAppKustomization(stackAppDir string, basePath string) (string, e
 	}
 
 	// Create the kustomization file for the stack directory.
+	// We explicitly do not set namespace because we want to use the default namespace set in each kustomize
+	// application.
 	kustomization.TypeMeta = types.TypeMeta{
 		Kind:       "Kustomization",
 		APIVersion: "kustomize.config.k8s.io/v1beta1",
 	}
-
-	kustomization.Namespace = "kubeflow"
 
 	hasBasePath := false
 	for _, r := range kustomization.Resources {

--- a/pkg/kfapp/kustomize/kustomize_test.go
+++ b/pkg/kfapp/kustomize/kustomize_test.go
@@ -1,8 +1,8 @@
 package kustomize
 
 import (
-	"bytes"
 	"github.com/ghodss/yaml"
+	"github.com/google/go-cmp/cmp"
 	"io/ioutil"
 	"os"
 	"path"
@@ -66,8 +66,9 @@ func TestGenerateKustomizationFile(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to read expected kustomization.yaml: %v", err)
 		}
-		if bytes.Compare(data, expected) != 0 {
-			t.Fatalf("kustomization.yaml is different from expected.\nactual:\n--------\n%s\nexpected:\n--------\n%s\n", string(data), string(expected))
+
+		if diff := cmp.Diff(expected, data); diff != "" {
+			t.Fatalf("kustomization.yaml is different from expected. (-want, +got):\n%s", diff)
 		}
 	}
 }
@@ -103,8 +104,8 @@ func TestGenerateYamlWithOwnerReferences(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to read expected file. Error: %v", err)
 		}
-		if bytes.Compare(actual, expected) != 0 {
-			t.Fatalf("Set owner reference is different from expected.\nactual:\n--------\n%s\nexpected:\n--------\n%s\n", string(actual), string(expected))
+		if diff := cmp.Diff(expected, actual); diff != "" {
+			t.Fatalf("Set owner reference is different from expected. (-want, +got):\n%s", diff)
 		}
 	}
 }
@@ -191,9 +192,9 @@ func TestCreateStackAppKustomization(t *testing.T) {
 
 		expectedStr := strings.TrimSpace(string(expected))
 		dataStr := strings.TrimSpace(string(data))
-
-		if dataStr != expectedStr {
-			t.Fatalf("kustomization.yaml is different from expected.\nactual:\n--------\n%s\nexpected:\n--------\n%s\n", dataStr, expectedStr)
+		
+		if diff := cmp.Diff(expectedStr, dataStr); diff != "" {
+			t.Fatalf("kustomization.yaml is different from expected. (-want, +got):\n%s", diff)
 		}
 	}
 }

--- a/pkg/kfapp/kustomize/kustomize_test.go
+++ b/pkg/kfapp/kustomize/kustomize_test.go
@@ -127,7 +127,6 @@ func TestCreateStackAppKustomization(t *testing.T) {
 					APIVersion: "kustomize.config.k8s.io/v1beta1",
 					Kind:       "Kustomization",
 				},
-				Namespace: "kubeflow",
 				Resources: []string{
 					"../../.cache/stacks/gcp",
 				},
@@ -146,7 +145,6 @@ func TestCreateStackAppKustomization(t *testing.T) {
 					APIVersion: "kustomize.config.k8s.io/v1beta1",
 					Kind:       "Kustomization",
 				},
-				Namespace: "kubeflow",
 				Resources: []string{
 					"../../.cache/stacks/gcp",
 				},

--- a/pkg/kfconfig/types.go
+++ b/pkg/kfconfig/types.go
@@ -5,27 +5,32 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
+	"github.com/ghodss/yaml"
+	"github.com/hashicorp/go-getter/helper/url"
+	kfapis "github.com/kubeflow/kfctl/v3/pkg/apis"
+	kftypesv3 "github.com/kubeflow/kfctl/v3/pkg/apis/apps"
+	"github.com/otiai10/copy"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"io"
 	"io/ioutil"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"net/http"
 	"os"
 	"path"
 	"path/filepath"
+	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"strings"
-
-	"github.com/ghodss/yaml"
-	"github.com/hashicorp/go-getter/helper/url"
-	kfapis "github.com/kubeflow/kfctl/v3/pkg/apis"
-	"github.com/otiai10/copy"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
 	DefaultCacheDir = ".cache"
+	// KfAppsStackName is the name that should be assigned to the application corresponding to the kubeflow
+	// application stack.
+	KfAppsStackName = "kubeflow-apps"
+	KustomizeDir    = "kustomize"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -665,8 +670,118 @@ func (c *KfConfig) GetApplicationParameter(appName string, paramName string) (st
 	return "", false
 }
 
-// SetApplicationParameter sets the desired application parameter.
-func (c *KfConfig) SetApplicationParameter(appName string, paramName string, value string) error {
+// addPatchStratgicMerge adds the patchFile to the strategic merge if it isn't already present.
+// Returns true if it is added
+func addPatchStratgicMerge(k *types.Kustomization, patchFile string) bool {
+	for _, p := range k.PatchesStrategicMerge {
+		if string(p) == patchFile {
+			log.Infof("kustomization already defines a patch for %v", patchFile)
+			return false
+		}
+	}
+
+	k.PatchesStrategicMerge = append(k.PatchesStrategicMerge, types.PatchStrategicMerge(patchFile))
+
+	return true
+}
+
+// setApplicationParameterInConfigMap sets an application parameter by creatign or modifying a configMap
+// generator.
+// kustomizeDir: Directory of the kustomize application
+// appName: Name of the application
+// paramName: Name of the parameter
+// value: Value of the parameter
+//
+// N.B. In the YAML for the generated config map patch the creationTimeStamp is set to null. This appears to
+// be the result of how the struct is serialized. Hopefully having this field in the output doesn't cause problems
+// with kustomize and kubectl.
+func setApplicationParameterInConfigMap(kustomizeDir string, appName string, paramName string, value string) error {
+	if _, err := os.Stat(kustomizeDir); err == nil {
+		// Noop if the directory already exists.
+	} else if os.IsNotExist(err) {
+		log.Infof("Creating kustomize directory %v", kustomizeDir)
+		if err := os.MkdirAll(kustomizeDir, os.ModePerm); err != nil {
+			return errors.WithStack(errors.Wrapf(err, "Could not create directory: %v", kustomizeDir))
+		}
+	} else {
+		log.Errorf("Error checking directory %v; error %v", kustomizeDir, err)
+		return errors.WithStack(err)
+	}
+
+	kustomizationFile := filepath.Join(kustomizeDir, kftypesv3.KustomizationFile)
+
+	contents, err := ioutil.ReadFile(kustomizationFile)
+
+	k := &types.Kustomization{}
+
+	// The kustomization file may not exist yet in which case we keep going because we will just create it.
+	if err == nil {
+		if err := yaml.Unmarshal(contents, k); err != nil {
+			return errors.WithStack(errors.Wrapf(err, "Failed to unmashal kustomization.yaml: %v", kustomizationFile))
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return errors.WithStack(errors.Wrapf(err, "Failed to read: %v", kustomizationFile))
+	}
+
+	configMapFileName := appName + "-config.yaml"
+
+	if addPatchStratgicMerge(k, configMapFileName) {
+		yaml, err := yaml.Marshal(k)
+
+		if err != nil {
+			return errors.WithStack(errors.Wrapf(err, "Error trying to marshal kustomization for kubeflow application: %v", appName))
+		}
+
+		kustomizationFileErr := ioutil.WriteFile(kustomizationFile, yaml, 0644)
+		if kustomizationFileErr != nil {
+			return errors.WithStack(errors.Wrapf(kustomizationFileErr, "Error writing file: %v", kustomizationFile))
+		}
+	}
+
+	// Patch the parameter into the configmap.
+	c := &v1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              appName + "-config",
+			CreationTimestamp: metav1.Time{},
+		},
+	}
+
+	configMapPath := filepath.Join(kustomizeDir, configMapFileName)
+	if contents, err := ioutil.ReadFile(configMapPath); err == nil {
+		if err := yaml.Unmarshal(contents, c); err != nil {
+			return errors.WithStack(errors.Wrapf(err, "Error reading configmap from file: %v", configMapPath))
+		}
+	} else if !os.IsNotExist(err) {
+		return errors.WithStack(errors.Wrapf(err, "Error trying to read file: %v", configMapPath))
+	}
+
+	if c.Data == nil {
+		c.Data = map[string]string{}
+	}
+	c.Data[paramName] = value
+
+	newContents, err := yaml.Marshal(c)
+
+	if err != nil {
+		return errors.WithStack(errors.Wrapf(err, "Error while marshaling patch for configMap %v", configMapPath))
+	}
+
+	if err := ioutil.WriteFile(configMapPath, newContents, os.ModePerm); err != nil {
+		return errors.WithStack(errors.Wrapf(err, "Error while writing patch file: %v", configMapPath))
+	}
+
+	return nil
+}
+
+// legacySetApplicationParameter sets the desired application parameter.
+//
+// This is the legacy version of KFDef that predates the use of kustomize stacks. In this case
+// application parameters are set by modifying the Applications in the KFDef spec.
+func (c *KfConfig) legacySetApplicationParameter(appName string, paramName string, value string) error {
 	// First we check applications for an application with the specified name.
 	if c.Spec.Applications != nil {
 		appIndex := -1
@@ -693,6 +808,28 @@ func (c *KfConfig) SetApplicationParameter(appName string, paramName string, val
 	return nil
 }
 
+// SetApplicationParameter sets the desired application parameter.
+func (c *KfConfig) SetApplicationParameter(appName string, paramName string, value string) error {
+	if c.UsingStacks() {
+		kustomizeDir := filepath.Join(c.Spec.AppDir, KustomizeDir, KfAppsStackName)
+		return setApplicationParameterInConfigMap(kustomizeDir, appName, paramName, value)
+	}
+	return c.legacySetApplicationParameter(appName, paramName, value)
+}
+
+// UsingStacks returns true if the KfDef is using kustomize to collect all of the Kubeflow applications
+func (c *KfConfig) UsingStacks() bool {
+	if c.Spec.Applications == nil {
+		return false
+	}
+
+	for _, a := range c.Spec.Applications {
+		if a.Name == KfAppsStackName {
+			return true
+		}
+	}
+	return false
+}
 func (c *KfConfig) DeleteApplication(appName string) error {
 	// First we check applications for an application with the specified name.
 	if c.Spec.Applications != nil {

--- a/pkg/kfconfig/types.go
+++ b/pkg/kfconfig/types.go
@@ -811,7 +811,7 @@ func (c *KfConfig) legacySetApplicationParameter(appName string, paramName strin
 // SetApplicationParameter sets the desired application parameter.
 func (c *KfConfig) SetApplicationParameter(appName string, paramName string, value string) error {
 	if c.UsingStacks() {
-		kustomizeDir := filepath.Join(c.Spec.AppDir, KustomizeDir, KfAppsStackName)
+		kustomizeDir := filepath.Join(c.Spec.AppDir, KustomizeDir, appName)
 		return setApplicationParameterInConfigMap(kustomizeDir, appName, paramName, value)
 	}
 	return c.legacySetApplicationParameter(appName, paramName, value)


### PR DESCRIPTION
kfctl should support using kustomize to compose a stack of applications.

* Design doc: http://bit.ly/kf_kustomize_v3
* Issue: kubeflow/manifests#774

* Update kfctl to properly generate a kustomize application based on the
  Kubeflow application stack. The new application will use as a base
  the stack as provided in the KfDef.

Here's how this works. A KFDef would define a new application "kubeflow-apps"

```
apiVersion: kfdef.apps.kubeflow.org/v1
kind: KfDef
metadata:
  creationTimestamp: null
  name: stack_test
  namespace: kubeflow
spec:
  applications:
  - kustomizeConfig:
      repoRef:
        name: manifests
        path: stacks/gcp
    name: kubeflow-apps
```

* The "path" would point to a kustomize application that composes all of the packages to be deployed.
* Instead of copying this kustomize package to ${KFAPP}/kustomize, kfctl defines a new kustomize application that uses the stack as a base
  * The advantage of this approach is that to upgrade and pull in any changes the user just
     needs to refresh the .cache directory

* For this application we change the logic for setting application parameters; instead of modifying the parameters in the KFDef we generate a configmap patch for the application that sets the
  parameter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfctl/288)
<!-- Reviewable:end -->
