### PR TITLE
Add support to kfctl to allow deployment on PPC64LE aka IBM Power architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,19 +170,19 @@ push-to-github-release: build-kfctl-tgz
 	    --repo kubeflow \
 	    --tag $(TAG) \
 	    --name "kfctl_$(TAG)_linux.tar.gz" \
-	    --file bin/kfctl_$(TAG)_linux.tar.gz
+	    --file bin/linux/kfctl_$(TAG)_linux.tar.gz
 	github-release upload \
 	    --user kubeflow \
 	    --repo kubeflow \
 	    --tag $(TAG) \
 	    --name "kfctl_$(TAG)_darwin.tar.gz" \
-	    --file bin/kfctl_$(TAG)_darwin.tar.gz
+	    --file bin/darwin/kfctl_$(TAG)_darwin.tar.gz
 	github-release upload \
             --user kubeflow \
             --repo kubeflow \
             --tag $(TAG) \
             --name "kfctl_$(TAG)_ppc64le.tar.gz" \
-            --file bin/kfctl_$(TAG)_ppc64le.tar.gz
+            --file bin/ppc64le/kfctl_$(TAG)_ppc64le.tar.gz
 
 build-kfctl-container:
 	DOCKER_BUILDKIT=1 docker build \

--- a/Makefile
+++ b/Makefile
@@ -126,14 +126,16 @@ build-kfctl: deepcopy generate fmt vet
 	#GOOS=windows GOARCH=amd64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/windows/kfctl.exe cmd/kfctl/main.go
 	GOOS=darwin GOARCH=amd64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=${TAG}" -o bin/darwin/kfctl cmd/kfctl/main.go
 	GOOS=linux GOARCH=amd64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/linux/kfctl cmd/kfctl/main.go
-	cp bin/$(ARCH)/kfctl bin/kfctl
+	GOOS=linux GOARCH=ppc64le ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/ppc64le/kfctl cmd/kfctl/main.go
+	#cp bin/$(ARCH)/kfctl bin/kfctl
 
 # Release tarballs suitable for upload to GitHub release pages
 build-kfctl-tgz: build-kfctl
-	chmod a+rx ./bin/kfctl
+	chmod a+rx ./bin/$(ARCH)/kfctl
 	rm -f bin/*.tgz
 	cd bin/linux && tar -cvzf kfctl_$(TAG)_linux.tar.gz ./kfctl
 	cd bin/darwin && tar -cvzf kfctl_${TAG}_darwin.tar.gz ./kfctl
+	cd bin/ppc64le && tar -cvzf kfctl_${TAG}_ppc64le.tar.gz ./kfctl
 
 build-and-push-operator: build-operator push-operator
 
@@ -175,6 +177,12 @@ push-to-github-release: build-kfctl-tgz
 	    --tag $(TAG) \
 	    --name "kfctl_$(TAG)_darwin.tar.gz" \
 	    --file bin/kfctl_$(TAG)_darwin.tar.gz
+	github-release upload \
+            --user kubeflow \
+            --repo kubeflow \
+            --tag $(TAG) \
+            --name "kfctl_$(TAG)_ppc64le.tar.gz" \
+            --file bin/kfctl_$(TAG)_ppc64le.tar.gz
 
 build-kfctl-container:
 	DOCKER_BUILDKIT=1 docker build \


### PR DESCRIPTION
I'm continuing a project that added support to Kubeflow that allowed deployment on ppc64le. 

Rather than keep seperate repositories, I feel it would be best suited to be included within the Kubeflow repository. This allows for one central place to pull Kubeflow regardless of the underlying compute architecture.