### PR TITLE
GCP: remove dependecies from DM & IAM hack

### DIFF
--- a/pkg/kfapp/gcp/gcp_test.go
+++ b/pkg/kfapp/gcp/gcp_test.go
@@ -145,12 +145,6 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 						},
 					},
 				},
-				DeploymentManagerConfig: &gcpplugin.DeploymentManagerConfig{
-					RepoRef: &kfconfig.RepoRef{
-						Name: "kubeflow",
-						Path: "deployment/gke/deployment_manager_configs",
-					},
-				},
 			},
 		},
 		{
@@ -174,12 +168,6 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 						},
 					},
 				},
-				DeploymentManagerConfig: &gcpplugin.DeploymentManagerConfig{
-					RepoRef: &kfconfig.RepoRef{
-						Name: "kubeflow",
-						Path: "deployment/gke/deployment_manager_configs",
-					},
-				},
 			},
 		},
 		{
@@ -201,12 +189,6 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 						OAuthClientSecret: &kfconfig.SecretRef{
 							Name: CLIENT_SECRET,
 						},
-					},
-				},
-				DeploymentManagerConfig: &gcpplugin.DeploymentManagerConfig{
-					RepoRef: &kfconfig.RepoRef{
-						Name: "kubeflow",
-						Path: "deployment/gke/deployment_manager_configs",
 					},
 				},
 				Project: "myproject",
@@ -248,12 +230,6 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 						},
 					},
 				},
-				DeploymentManagerConfig: &gcpplugin.DeploymentManagerConfig{
-					RepoRef: &kfconfig.RepoRef{
-						Name: "kubeflow",
-						Path: "deployment/gke/deployment_manager_configs",
-					},
-				},
 				Email: "myemail",
 			},
 			EmailGetter: func() (string, error) {
@@ -285,12 +261,6 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 						OAuthClientSecret: &kfconfig.SecretRef{
 							Name: CLIENT_SECRET,
 						},
-					},
-				},
-				DeploymentManagerConfig: &gcpplugin.DeploymentManagerConfig{
-					RepoRef: &kfconfig.RepoRef{
-						Name: "kubeflow",
-						Path: "deployment/gke/deployment_manager_configs",
 					},
 				},
 				Email: "myemail",
@@ -331,12 +301,6 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 						},
 					},
 				},
-				DeploymentManagerConfig: &gcpplugin.DeploymentManagerConfig{
-					RepoRef: &kfconfig.RepoRef{
-						Name: "kubeflow",
-						Path: "deployment/gke/deployment_manager_configs",
-					},
-				},
 			},
 		},
 		{
@@ -368,12 +332,6 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 						Password: &kfconfig.SecretRef{
 							Name: "original_secret",
 						},
-					},
-				},
-				DeploymentManagerConfig: &gcpplugin.DeploymentManagerConfig{
-					RepoRef: &kfconfig.RepoRef{
-						Name: "kubeflow",
-						Path: "deployment/gke/deployment_manager_configs",
 					},
 				},
 			},

--- a/pkg/kfconfig/types_test.go
+++ b/pkg/kfconfig/types_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
 	"github.com/prometheus/common/log"
 	"io"
 	"io/ioutil"
@@ -25,14 +26,13 @@ import (
 	"path"
 	"reflect"
 	"testing"
-	"github.com/pkg/errors"
 )
 
 func TestSyncCache(t *testing.T) {
 	type testCase struct {
-		input    			*KfConfig
-		expected 			[]Cache
-		expectedErr		error
+		input       *KfConfig
+		expected    []Cache
+		expectedErr error
 	}
 
 	// Verify that we can sync some files.
@@ -95,7 +95,7 @@ func TestSyncCache(t *testing.T) {
 					},
 				},
 			},
-			expected: nil,
+			expected:    nil,
 			expectedErr: errors.New("SyncCache: could not sync cache when the cache path " + path.Join(srcDir, "app1", ".cache", repoName) + " is sub directory of manifests " + srcDir),
 		},
 		{


### PR DESCRIPTION
kfdef:
Make DM config & IAM hack config optional for platform == GCP:
* Currently during `kfdef build` & `kfdef apply`, kfdef assumes DM config is required when kfdef's platform == GCP, and would fill default value for DM config entry.  
With this PR we make DM config optional: kfdef only apply DM config when it is configured in kfdef. 
* Current `IAM hack` during `kfdef apply`: kfdef will clear GCP SA's roles and re-apply them to clean any existing leftover from previous deployment (and assume IAM template config exists) 
With this PR we run `IAM hack` only when IAM template config exists, since when KCC replaced DM, IAM roles leftover should be cleaned by KCC. 