### PR TITLE
To support stacks kfctl update mapping for spatakus and compute relative directory of cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,8 +131,7 @@ build-kfctl: deepcopy generate fmt vet
 # Fast rebuilds useful for development.
 # Does not regenerate code; assumes you already ran build-kfctl once.
 build-kfctl-fast: fmt vet
-	GOOS=linux GOARCH=amd64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/linux/kfctl cmd/kfctl/main.go
-	cp bin/$(ARCH)/kfctl bin/kfctl
+	GOOS=linux GOARCH=amd64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/linux/kfctl cmd/kfctl/main.go	
 
 # Release tarballs suitable for upload to GitHub release pages
 build-kfctl-tgz: build-kfctl

--- a/pkg/kfapp/kustomize/kustomize.go
+++ b/pkg/kfapp/kustomize/kustomize.go
@@ -517,6 +517,22 @@ func (kustomize *kustomize) Generate(resources kftypesv3.ResourceEnum) error {
 			appPath := path.Join(repoCache.LocalPath, app.KustomizeConfig.RepoRef.Path)
 
 			if kustomize.kfDef.UsingStacks() {
+
+				if filepath.IsAbs(appPath) {
+					// The appPath needs to be a relative path because we use it as a resource location in the kustomize
+					// file
+					appDir, err := filepath.Abs(kustomize.kfDef.Spec.AppDir)
+
+					if err != nil {
+						errors.WithStack(fmt.Errorf("There was a problem computing absolute path of %v; error; %v ", kustomize.kfDef.Spec.AppDir, err))
+					}
+					relPath, err := filepath.Rel(appDir, appPath)
+					if err != nil {
+						errors.WithStack(fmt.Errorf("There was a problem computing filePath.Rel(%v, %v); error; %v ", appDir, appPath, err))
+					}
+
+					appPath = relPath
+				}
 				// We handle generating the kustomize dir for application stacks differently.
 				stackAppDir := path.Join(kustomizeDir, app.Name)
 

--- a/pkg/kfconfig/types.go
+++ b/pkg/kfconfig/types.go
@@ -822,12 +822,14 @@ func (c *KfConfig) SetApplicationParameter(appName string, paramName string, val
 		appToStack := map[string]string{
 			"centraldashboard": KfAppsStackName,
 			"cloud-endpoints":  "cloud-endpoints",
-			"default-install":  "default-install",
+			"default-install":  KfAppsStackName,
 			"istio-stack":      "istio-stack",
 			"iap-ingress":      "iap-ingress",
 			"jupyter-web-app":  KfAppsStackName,
 			"metacontroller":   "metacontroller",
 			"profiles":         KfAppsStackName,
+			// Spartakus is its own application because we want kfctl to be able to remove it.
+			"spartakus": "spartakus",
 		}
 
 		appNameDir, ok := appToStack[appName]


### PR DESCRIPTION
* When using a local file path for the repo, we need to compute the relative
  path of the directory from the absolute path of the cache. This is
  because this path is used to set the path to the kustomize package used
  as a resource in the kustomization.yaml. kustomize only allows relative
  paths.

* Need to update the mapping of apps to stacks.