### PR TITLE
Fix kfctl builds; use gomodules with deepcopy-gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,42 +71,42 @@ generate:
 	@${GO} generate ./config ./pkg/apis/apps/kfdef/... ./pkg/utils/... ./pkg/kfapp/minikube ./pkg/kfapp/gcp/... ./cmd/kfctl/...
 
 ${GOPATH}/bin/deepcopy-gen:
-	GO111MODULE=off ${GO} get k8s.io/code-generator/cmd/deepcopy-gen
+	GO111MODULE=on ${GO} get k8s.io/code-generator/cmd/deepcopy-gen
 
 config/zz_generated.deepcopy.go: config/types.go
-	${GOPATH}/bin/deepcopy-gen -i github.com/kubeflow/kfctl/v3/config -O zz_generated.deepcopy && \
+	${GOPATH}/bin/deepcopy-gen -h hack/boilerplate.go.txt -i github.com/kubeflow/kfctl/v3/config -O zz_generated.deepcopy && \
 	mv ${GOPATH}/src/github.com/kubeflow/kfctl/v3/config/zz_generated.deepcopy.go config/ && rm -rf v3
 
 pkg/apis/apps/kfdef/v1alpha1/zz_generated.deepcopy.go: pkg/apis/apps/kfdef/v1alpha1/application_types.go
-	${GOPATH}/bin/deepcopy-gen -i github.com/kubeflow/kfctl/v3/pkg/apis/apps/kfdef/... -O zz_generated.deepcopy && \
+	${GOPATH}/bin/deepcopy-gen -h hack/boilerplate.go.txt -i github.com/kubeflow/kfctl/v3/pkg/apis/apps/kfdef/... -O zz_generated.deepcopy && \
 	mv ${GOPATH}/src/github.com/kubeflow/kfctl/v3/pkg/apis/apps/kfdef/v1alpha1/zz_generated.deepcopy.go pkg/apis/apps/kfdef/v1alpha1/ && rm -rf v3
 
 pkg/apis/apps/kfdef/v1beta1/zz_generated.deepcopy.go: pkg/apis/apps/kfdef/v1beta1/application_types.go
-	${GOPATH}/bin/deepcopy-gen -i github.com/kubeflow/kfctl/v3/pkg/apis/apps/kfdef/... -O zz_generated.deepcopy && \
+	${GOPATH}/bin/deepcopy-gen -h hack/boilerplate.go.txt -i github.com/kubeflow/kfctl/v3/pkg/apis/apps/kfdef/... -O zz_generated.deepcopy && \
 	mv ${GOPATH}/src/github.com/kubeflow/kfctl/v3/pkg/apis/apps/kfdef/v1beta1/zz_generated.deepcopy.go pkg/apis/apps/kfdef/v1beta1/ && rm -rf v3
 
 pkg/apis/apps/kfdef/v1/zz_generated.deepcopy.go: pkg/apis/apps/kfdef/v1/application_types.go
-	${GOPATH}/bin/deepcopy-gen -i github.com/kubeflow/kfctl/v3/pkg/apis/apps/kfdef/... -O zz_generated.deepcopy && \
+	${GOPATH}/bin/deepcopy-gen -h hack/boilerplate.go.txt -i github.com/kubeflow/kfctl/v3/pkg/apis/apps/kfdef/... -O zz_generated.deepcopy && \
 	mv ${GOPATH}/src/github.com/kubeflow/kfctl/v3/pkg/apis/apps/kfdef/v1/zz_generated.deepcopy.go pkg/apis/apps/kfdef/v1/ && rm -rf v3
 
 pkg/apis/apps/plugins/gcp/v1alpha1/zz_generated.deepcopy.go: pkg/apis/apps/plugins/gcp/v1alpha1/types.go
-	${GOPATH}/bin/deepcopy-gen -i github.com/kubeflow/kfctl/v3/pkg/apis/apps/plugins/gcp/... -O zz_generated.deepcopy && \
+	${GOPATH}/bin/deepcopy-gen -h hack/boilerplate.go.txt -i github.com/kubeflow/kfctl/v3/pkg/apis/apps/plugins/gcp/... -O zz_generated.deepcopy && \
 	mv ${GOPATH}/src/github.com/kubeflow/kfctl/v3/pkg/apis/apps/plugins/gcp/v1alpha1/zz_generated.deepcopy.go pkg/apis/apps/plugins/gcp/v1alpha1/ && rm -rf v3
 
 pkg/apis/apps/plugins/aws/v1alpha1/zz_generated.deepcopy.go: pkg/apis/apps/plugins/aws/v1alpha1/types.go
-	${GOPATH}/bin/deepcopy-gen -i github.com/kubeflow/kfctl/v3/pkg/apis/apps/plugins/aws/... -O zz_generated.deepcopy && \
+	${GOPATH}/bin/deepcopy-gen -h hack/boilerplate.go.txt -i github.com/kubeflow/kfctl/v3/pkg/apis/apps/plugins/aws/... -O zz_generated.deepcopy && \
 	mv ${GOPATH}/src/github.com/kubeflow/kfctl/v3/pkg/apis/apps/plugins/aws/v1alpha1/zz_generated.deepcopy.go pkg/apis/apps/plugins/aws/v1alpha1/ && rm -rf v3
 
 pkg/kfconfig/zz_generated.deepcopy.go: pkg/kfconfig/types.go
-	${GOPATH}/bin/deepcopy-gen -i github.com/kubeflow/kfctl/v3/pkg/kfconfig/... -O zz_generated.deepcopy && \
+	${GOPATH}/bin/deepcopy-gen -h hack/boilerplate.go.txt -i github.com/kubeflow/kfctl/v3/pkg/kfconfig/... -O zz_generated.deepcopy && \
 	mv ${GOPATH}/src/github.com/kubeflow/kfctl/v3/pkg/kfconfig/zz_generated.deepcopy.go pkg/kfconfig/ && rm -rf v3
 
 pkg/kfconfig/awsplugin/zz_generated.deepcopy.go: pkg/kfconfig/awsplugin/types.go
-	${GOPATH}/bin/deepcopy-gen -i github.com/kubeflow/kfctl/v3/pkg/kfconfig/awsplugin/... -O zz_generated.deepcopy && \
+	${GOPATH}/bin/deepcopy-gen -h hack/boilerplate.go.txt -i github.com/kubeflow/kfctl/v3/pkg/kfconfig/awsplugin/... -O zz_generated.deepcopy && \
 	mv ${GOPATH}/src/github.com/kubeflow/kfctl/v3/pkg/kfconfig/awsplugin/zz_generated.deepcopy.go pkg/kfconfig/awsplugin/ && rm -rf v3
 
 pkg/kfconfig/gcpplugin/zz_generated.deepcopy.go: pkg/kfconfig/gcpplugin/types.go
-	${GOPATH}/bin/deepcopy-gen -i github.com/kubeflow/kfctl/v3/pkg/kfconfig/gcpplugin/... -O zz_generated.deepcopy && \
+	${GOPATH}/bin/deepcopy-gen -h hack/boilerplate.go.txt -i github.com/kubeflow/kfctl/v3/pkg/kfconfig/gcpplugin/... -O zz_generated.deepcopy && \
 	mv ${GOPATH}/src/github.com/kubeflow/kfctl/v3/pkg/kfconfig/gcpplugin/zz_generated.deepcopy.go pkg/kfconfig/gcpplugin/ && rm -rf v3
 
 deepcopy: ${GOPATH}/bin/deepcopy-gen config/zz_generated.deepcopy.go \

--- a/cmd/kfctl/cmd/init.go
+++ b/cmd/kfctl/cmd/init.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 package cmd
 

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	k8s.io/apimachinery v0.17.1
 	k8s.io/cli-runtime v0.0.0
 	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/code-generator v0.18.1 // indirect
 	k8s.io/kubernetes v1.16.2
 	k8s.io/utils v0.0.0-20191030222137-2b95a09bc58d // indirect
 	sigs.k8s.io/controller-runtime v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -1110,6 +1110,7 @@ k8s.io/client-go v0.0.0-20190620085101-78d2af792bab h1:E8Fecph0qbNsAbijJJQryKu4O
 k8s.io/client-go v0.0.0-20190620085101-78d2af792bab/go.mod h1:E95RaSlHr79aHaX0aGSwcPNfygDiPKOVXdmivCIZT0k=
 k8s.io/cloud-provider v0.0.0-20190620090043-8301c0bda1f0/go.mod h1:UXU55LeVTrjyQNw86sHjagiYhSZjYxWKXvx0Ml17KvM=
 k8s.io/cluster-bootstrap v0.0.0-20190620090013-c9a0fc045dc1/go.mod h1:cCRw3eZzlJdySYRtkL/N4cAClxYCzyrBL3V8cblTlUo=
+k8s.io/code-generator v0.0.0-20190612205613-18da4a14b22b h1:p+PRuwXWwk5e+UYvicGiavEupapqM5NOxUl3y1GkD6c=
 k8s.io/code-generator v0.0.0-20190612205613-18da4a14b22b/go.mod h1:G8bQwmHm2eafm5bgtX67XDZQ8CWKSGu9DekI+yN4Y5I=
 k8s.io/component-base v0.0.0-20190620085130-185d68e6e6ea/go.mod h1:VLedAFwENz2swOjm0zmUXpAP2mV55c49xgaOzPBI/QQ=
 k8s.io/cri-api v0.0.0-20190531030430-6117653b35f1/go.mod h1:K6Ux7uDbzKhacgqW0OJg3rjXk/SR9kprCPfSUDXGB5A=
@@ -1117,6 +1118,7 @@ k8s.io/csi-translation-lib v0.0.0-20190620090116-299a7b270edc/go.mod h1:L51Xd2Iw
 k8s.io/gengo v0.0.0-20190116091435-f8a0810f38af/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20191010091904-7fa3014cb28f/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20191108084044-e500ee069b5c h1:iraFntD6FA5K/hBaPW2z/ZItJZEG63uc3ak5S0oDVEo=
 k8s.io/gengo v0.0.0-20191108084044-e500ee069b5c/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/heapster v1.2.0-beta.1/go.mod h1:h1uhptVXMwC8xtZBYsPXKVi8fpdlYkTs6k949KozGrM=
 k8s.io/helm v2.16.1+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=

--- a/hack/boilerplate.go.txt
+++ b/hack/boilerplate.go.txt
@@ -1,0 +1,16 @@
+ 
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/

--- a/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
+++ b/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
@@ -516,7 +516,7 @@ class Builder(object):
     self.workflow = self._build_workflow()
     task_template = self._build_task_template()
     py3_template = argo_build_util.deep_copy(task_template)
-    py3_template["container"]["image"] = "gcr.io/kubeflow-ci/test-worker-py3:789005d"
+    py3_template["container"]["image"] = "gcr.io/kubeflow-ci/test-worker-py3:e9afed1-dirty"
 
     #**************************************************************************
     # Checkout

--- a/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
+++ b/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
@@ -295,7 +295,7 @@ class Builder(object):
         {"name": "TEST_TARGET_NAME",
          "value": self.test_target_name},
        ],
-      'image': 'gcr.io/kubeflow-ci/test-worker-py3:e9afed1-dirty',
+      'image': 'gcr.io/kubeflow-ci/test-worker:latest',
       'imagePullPolicy': 'Always',
       'name': '',
       'resources': {'limits': {'cpu': '4', 'memory': '4Gi'},
@@ -587,8 +587,8 @@ class Builder(object):
     ]
 
     dependences = [checkout["name"]]
-    build_kfctl = self._build_step(step_name, self.workflow, E2E_DAG_NAME, task_template,
-                                   command, dependences)
+    build_kfctl = self._build_step(step_name, self.workflow, E2E_DAG_NAME,
+                                   py3_template, command, dependences)
 
     #**************************************************************************
     # Wait for Kubeflow to be ready

--- a/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
+++ b/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
@@ -295,7 +295,7 @@ class Builder(object):
         {"name": "TEST_TARGET_NAME",
          "value": self.test_target_name},
        ],
-      'image': 'gcr.io/kubeflow-ci/test-worker:latest',
+      'image': 'gcr.io/kubeflow-ci/test-worker-py3:e9afed1-dirty',
       'imagePullPolicy': 'Always',
       'name': '',
       'resources': {'limits': {'cpu': '4', 'memory': '4Gi'},

--- a/testing/workflows/components/unit_tests.jsonnet
+++ b/testing/workflows/components/unit_tests.jsonnet
@@ -25,7 +25,7 @@ local srcRootDir = testDir + "/src";
 // The directory containing the kubeflow/kfctl repo
 local srcDir = srcRootDir + "/kubeflow/kfctl";
 
-local image = "gcr.io/kubeflow-ci/test-worker-py3:e9afed1-dirty";
+local image = "gcr.io/kubeflow-ci/test-worker-py3:f91eaf1-dirty";
 local testing_image = "gcr.io/kubeflow-ci/kubeflow-testing";
 
 // The name of the NFS volume claim to use for test files.
@@ -119,7 +119,7 @@ local dagTemplates = [
        ) + {
       someRandomField: "jeremy",
       container+:{
-        image: "gcr.io/kubeflow-ci/test-worker-py3:e9afed1-dirty",
+        image: "gcr.io/kubeflow-ci/test-worker-py3:f91eaf1-dirty",
       },
     },  // go-kfctl-unit-tests
     dependencies: ["checkout"],

--- a/testing/workflows/components/unit_tests.jsonnet
+++ b/testing/workflows/components/unit_tests.jsonnet
@@ -119,7 +119,7 @@ local dagTemplates = [
        ) + {
       someRandomField: "jeremy",
       container+:{
-        image: "gcr.io/kubeflow-ci/kfctl/builder:v20190418-v0-30-g5e3bd23d-dirty-73d1fe",
+        image: "gcr.io/kubeflow-ci/test-worker-py3:e9afed1-dirty",
       },
     },  // go-kfctl-unit-tests
     dependencies: ["checkout"],

--- a/testing/workflows/components/unit_tests.jsonnet
+++ b/testing/workflows/components/unit_tests.jsonnet
@@ -25,7 +25,7 @@ local srcRootDir = testDir + "/src";
 // The directory containing the kubeflow/kfctl repo
 local srcDir = srcRootDir + "/kubeflow/kfctl";
 
-local image = "gcr.io/kubeflow-ci/test-worker:latest";
+local image = "gcr.io/kubeflow-ci/test-worker-py3:e9afed1-dirty";
 local testing_image = "gcr.io/kubeflow-ci/kubeflow-testing";
 
 // The name of the NFS volume claim to use for test files.


### PR DESCRIPTION
* Fix #306; switching to go modules fixes the error:

```
GO111MODULE=off go get k8s.io/code-generator/cmd/deepcopy-gen
package k8s.io/klog/v2: cannot find package "k8s.io/klog/v2" in any of:
	/usr/local/go/src/k8s.io/klog/v2 (from $GOROOT)
	/tmp/go3/src/k8s.io/klog/v2 (from $GOPATH)
make: *** [Makefile:74: /tmp/go3/bin/deepcopy-gen] Error 1
```

* deepcopy-gen takes in an argument "-h" which points to a file
  containing boilerplate header code.

  * The default value is ${GOPATH}/src/k8s.io/code-generator/hack/boilerplate.go.txt
  * However, after updating to fetch it with go modules the source is no longer
    downloaded.
  * So we check in a copy of the boilerplate into hack/ and then pass that path
    as a parameter to deepcopy gen.