### PR TITLE
Enable arm64 kfctl binary build and fix docker build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,12 @@ RUN apt-get install -y git unzip jq vim
 RUN go get -u github.com/jstemmer/go-junit-report
 
 # We need gcloud to get gke credentials.
-RUN \
-    cd /tmp && \
-    wget -nv https://dl.google.com/dl/cloudsdk/release/install_google_cloud_sdk.bash && \
-    chmod +x install_google_cloud_sdk.bash && \
-    ./install_google_cloud_sdk.bash --disable-prompts --install-dir=/opt/
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+        cd /tmp && \
+        wget -nv https://dl.google.com/dl/cloudsdk/release/install_google_cloud_sdk.bash && \
+        chmod +x install_google_cloud_sdk.bash && \
+        ./install_google_cloud_sdk.bash --disable-prompts --install-dir=/opt/; \
+    fi
 
 ENV PATH /go/bin:/usr/local/go/bin:/opt/google-cloud-sdk/bin:${PATH}
 
@@ -49,7 +50,8 @@ COPY . .
 #
 FROM builder as kfctl_base
 
-RUN make build-kfctl
+RUN make build && \
+    cp bin/kfctl-$(go env GOOS)-$(go env GOARCH) bin/kfctl
 
 #**********************************************************************
 #

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@
 GCLOUD_PROJECT ?= kubeflow-images-public
 GOLANG_VERSION ?= 1.12.7
 GOPATH ?= $(HOME)/go
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
 # To build without the cache set the environment variable
 # export DOCKER_BUILD_OPTS=--no-cache
 KFCTL_IMG ?= gcr.io/$(GCLOUD_PROJECT)/kfctl
@@ -29,7 +31,6 @@ VERBOSE ?=
 PLUGINS_ENVIRONMENT ?= $(GOPATH)/src/github.com/kubeflow/kfctl/bin
 export GO111MODULE = on
 export GO = go
-ARCH ?= $(shell ${GO} env|grep GOOS|cut -d'=' -f2|tr -d '"')
 OPERATOR_IMG ?= kubeflow-operator
 IMAGE_BUILDER ?= docker
 DOCKERFILE ?= Dockerfile
@@ -122,26 +123,31 @@ deepcopy: ${GOPATH}/bin/deepcopy-gen config/zz_generated.deepcopy.go \
 	pkg/kfconfig/awsplugin/zz_generated.deepcopy.go \
 	pkg/kfconfig/gcpplugin/zz_generated.deepcopy.go
 
-build: build-kfctl
+build: bin/kfctl-linux-amd64 bin/kfctl-darwin-amd64 bin/kfctl-linux-arm64
 
-build-kfctl: deepcopy generate fmt vet
+bin/kfctl-linux-amd64: GOARGS = GOOS=linux GOARCH=amd64
+bin/kfctl-darwin-amd64: GOARGS = GOOS=darwin GOARCH=amd64
+#bin/kfctl-windows-amd64: GOARGS = GOOS=windows GOARCH=amd64
+bin/kfctl-linux-arm64: GOARGS = GOOS=linux GOARCH=arm64
+
+bin/kfctl-%: deepcopy generate fmt vet
 	# TODO(swiftdiaries): figure out import conflict errors for windows
 	#GOOS=windows GOARCH=amd64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/windows/kfctl.exe cmd/kfctl/main.go
-	GOOS=darwin GOARCH=amd64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=${TAG}" -o bin/darwin/kfctl cmd/kfctl/main.go
-	GOOS=linux GOARCH=amd64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/linux/kfctl cmd/kfctl/main.go
-	cp bin/$(ARCH)/kfctl bin/kfctl
+	CGO_ENABLED=0 ${GOARGS} ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=${TAG}" -o $@ cmd/kfctl/main.go
 
 # Fast rebuilds useful for development.
-# Does not regenerate code; assumes you already ran build-kfctl once.
+# Does not regenerate code; assumes you already ran build once.
 build-kfctl-fast: fmt vet
-	GOOS=linux GOARCH=amd64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/linux/kfctl cmd/kfctl/main.go	
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/kfctl-linux-amd64 cmd/kfctl/main.go
 
 # Release tarballs suitable for upload to GitHub release pages
-build-kfctl-tgz: build-kfctl
-	chmod a+rx ./bin/kfctl
+build-kfctl-tgz: build
+	chmod a+rx ./bin/kfctl*
 	rm -f bin/*.tgz
-	cd bin/linux && tar -cvzf kfctl_$(TAG)_linux.tar.gz ./kfctl
-	cd bin/darwin && tar -cvzf kfctl_${TAG}_darwin.tar.gz ./kfctl
+	cd bin && tar -cvzf kfctl_$(TAG)_linux_amd64.tar.gz ./kfctl-linux-amd64
+	cd bin && tar -cvzf kfctl_${TAG}_darwin_amd64.tar.gz ./kfctl-darwin-amd64
+	cd bin && tar -cvzf kfctl_$(TAG)_linux_arm64.tar.gz ./kfctl-linux-arm64
+
 
 build-and-push-operator: build-operator push-operator
 build-push-update-operator: build-operator push-operator update-operator-image
@@ -189,14 +195,20 @@ push-to-github-release: build-kfctl-tgz
 	    --user kubeflow \
 	    --repo kubeflow \
 	    --tag $(TAG) \
-	    --name "kfctl_$(TAG)_linux.tar.gz" \
-	    --file bin/kfctl_$(TAG)_linux.tar.gz
+	    --name "kfctl_$(TAG)_linux_amd64.tar.gz" \
+	    --file bin/kfctl_$(TAG)_linux_amd64.tar.gz
 	github-release upload \
 	    --user kubeflow \
 	    --repo kubeflow \
 	    --tag $(TAG) \
-	    --name "kfctl_$(TAG)_darwin.tar.gz" \
-	    --file bin/kfctl_$(TAG)_darwin.tar.gz
+	    --name "kfctl_$(TAG)_darwin_amd64.tar.gz" \
+	    --file bin/kfctl_$(TAG)_darwin_amd64.tar.gz
+	github-release upload \
+            --user kubeflow \
+            --repo kubeflow \
+            --tag $(TAG) \
+            --name "kfctl_$(TAG)_linux_arm64.tar.gz" \
+            --file bin/kfctl_$(TAG)_linux_arm64.tar.gz
 
 build-kfctl-container:
 	DOCKER_BUILDKIT=1 docker build \
@@ -242,9 +254,9 @@ push-kfctl-container-latest: push-kfctl-container
 	gcloud container images add-tag --quiet $(KFCTL_IMG):$(TAG) $(KFCTL_IMG):latest --verbosity=info
 	@echo created $(KFCTL_IMG):latest
 
-install: build-kfctl dockerfordesktop.so
-	@echo copying bin/kfctl to /usr/local/bin
-	@cp bin/kfctl /usr/local/bin
+install: build dockerfordesktop.so
+	@echo copying bin/kfctl-${GOOS}-${GOARCH} to /usr/local/bin/kfctl
+	@cp bin/kfctl-${GOOS}-${GOARCH} /usr/local/bin/kfctl
 
 run-kfctl-container: build-kfctl-container
 	docker run $(MOUNT_KUBE) $(MOUNT_GCP) --entrypoint /bin/sh -it $(KFCTL_IMG):$(TAG)
@@ -285,12 +297,12 @@ check-licenses:
 	./third_party/check-license.sh
 # rules to run unittests
 #
-test: build-kfctl check-licenses
+test: build check-licenses
 	go test ./... -v
 
 
 # Run the unittests and output a junit report for use with prow
-test-junit: build-kfctl
+test-junit: build
 	echo Running tests ... junit_file=$(JUNIT_FILE)
 	go test ./... -v 2>&1 | go-junit-report > $(JUNIT_FILE) --set-exit-code
 


### PR DESCRIPTION
Referencing issue #99 and kubeflow issue [#2337](https://github.com/kubeflow/kubeflow/issues/2337):

1. Adds support for building and releasing arm64 kfctl binary.
2. Fixes building error for target `build-kfctl-container` when executing `RUN go mod download` by upgrading the Golang version to v1.13.7.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>