### PR TITLE
Add Dockerfile.ubi and deploy by kustomize for operator

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,24 +1,25 @@
+ARG binary_name=kfctl
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS build
 
-ENV OPERATOR=/usr/local/bin/kfctl \
+ENV OPERATOR=/usr/local/bin/${binary_name} \
     USER_UID=1001 \
     USER_NAME=kfctl \
     HOMEDIR=/homedir
 
 # install operator binary
-COPY build/_output/bin/kfctl ${OPERATOR}
+COPY build/_output/bin/${binary_name} ${OPERATOR}
 
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
 RUN  /usr/local/bin/entrypoint
 
 FROM gcr.io/distroless/base-debian10
-ENV OPERATOR=/usr/local/bin/kfctl \
+ENV OPERATOR=/usr/local/bin/${binary_name} \
     USER_UID=1001 \
     USER_NAME=kfctl \
     HOMEDIR=/homedir
 
-COPY --from=build /usr/local/bin/kfctl /usr/local/bin/kfctl
+COPY --from=build /usr/local/bin/${binary_name} ${OPERATOR}
 COPY --from=build /etc/passwd /etc/passwd
 COPY --from=build ${HOMEDIR} ${HOME}
 

--- a/build/Dockerfile.ubi
+++ b/build/Dockerfile.ubi
@@ -1,0 +1,16 @@
+ARG binary_name=kfctl
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+ENV OPERATOR=/usr/local/bin/${binary_name}\
+    HOME=/opt/${binary_name}
+
+RUN mkdir -p ${HOME} &&\
+    chown 1001:0 ${HOME} &&\
+    chmod ug+rwx ${HOME}
+
+WORKDIR ${HOME}
+
+COPY build/_output/bin/${binary_name} ${OPERATOR}
+
+ENTRYPOINT ["${OPERATOR}"]
+
+USER 1001

--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -6,7 +6,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: kubeflow-operator
-  namespace: ${OPERATOR_NAMESPACE} # Replace it with operator's namespace
+  namespace: $(namespace) # Replace it with operator's namespace
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/deploy/crds/kustomization.yaml
+++ b/deploy/crds/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- kfdef_quota.yaml
+- kfdef.apps.kubeflow.org_kfdefs_crd.yaml

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -1,0 +1,20 @@
+namespace: kubeflow-operator
+
+bases:
+- ./crds
+- ./service_account.yaml
+- ./role.yaml
+- ./cluster_role_binding.yaml
+- ./operator.yaml
+
+vars:
+- fieldref:
+    fieldPath: metadata.namespace
+  name: namespace
+  objref:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kubeflow-operator
+
+configurations:
+- ./params.yaml

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -30,4 +30,6 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "kubeflow-operator"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name

--- a/deploy/params.yaml
+++ b/deploy/params.yaml
@@ -1,0 +1,4 @@
+varReference:
+- path: subjects/namespace
+  kind: ClusterRoleBinding
+  apiGroup: rbac.authorization.k8s.io/v1

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,2 @@
+bases:
+- kustomize/base

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -1,0 +1,2 @@
+bases:
+- ../../deploy

--- a/operator.md
+++ b/operator.md
@@ -5,15 +5,15 @@ Kubeflow Operator helps deploy, monitor and manage the lifecycle of Kubeflow. Bu
 The Operator is currently in incubation phase and is based on this [design doc](https://docs.google.com/document/d/1vNBZOM-gDMpwTbhx0EDU6lDpyUjc7vhT3bdOWWCRjdk/edit#). It is built on top of _kfdef_ CR, and uses _kfctl_ as the nucleus for Controller. Current roadmap for this Operator is listed [here](https://github.com/kubeflow/kfctl/issues/193). The Operator is also [published on OperatorHub](https://operatorhub.io/operator/kubeflow)
 
 ## Deployment Instructions
-1. Clone this repository and deploy the CRD and controller
+1. Clone this repository and use Kustomize to build the manifests
 ```shell
 # git clone https://github.com/kubeflow/kfctl.git && cd kfctl
 OPERATOR_NAMESPACE=operators
 kubectl create ns ${OPERATOR_NAMESPACE}
-kubectl create -f deploy/crds/kfdef.apps.kubeflow.org_kfdefs_crd.yaml
-kubectl create -f deploy/service_account.yaml -n ${OPERATOR_NAMESPACE}
-kubectl create clusterrolebinding kubeflow-operator --clusterrole cluster-admin --serviceaccount=${OPERATOR_NAMESPACE}:kubeflow-operator
-kubectl create -f deploy/operator.yaml -n ${OPERATOR_NAMESPACE}
+
+cd deploy/
+kustomize edit set namespace ${OPERATOR_NAMESPACE}
+kustomize build | kubectl apply -f -
 ```
 
 2. Setup Kubeflow namespace. You can optionally apply ResourceQuota if your Kubernetes version is 1.15+, which will allow only one _kfdef_ instance or one deployment of Kubeflow on the cluster. This follows the singleton model, and is the current recommended and supported mode.
@@ -131,6 +131,7 @@ kubectl delete mutatingwebhookconfigurations mutating-webhook-configurations
 ### Prerequisites
 1. Install [operator-sdk](https://github.com/operator-framework/operator-sdk/blob/master/doc/user/install-operator-sdk.md)
 2. Install [golang](https://golang.org/dl/)
+3. Install [kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md)
 
 
 ## Build Instructions


### PR DESCRIPTION
This PR:

* Adds `Dockerfile.ubi` for UBI based operator image
* Make `Makefile` and `build-operator` more flexible to configure
  * `DOCKERFILE` for Dockerfile name
  * `IMAGE_BUILDER` to allow using `podman` to build the image
  * `OPERATOR_BINARY_NAME` - since `operator-sdk` uses the folder name for output controller binary, this variable parameterizes that (e.g. our fork is called `opendatahub-operator` and thus the binary name != `kfctl`)
* Add Kustomize for deployment manifests to simply run
  * `kustomize build deploy/` 
  * This allows simple extensibility and configurability for the deployment manifests (e.g. Open Data Hub will be able to rename some of the resources to `opendatahub-operator` without actually forking the manifests)

Should I also replace the `perl` line in Makefile with `kustomize set` ? 