### PR TITLE
tie kfapp directory with kfdef name and namespace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go v1.27.1
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1 // indirect
-	github.com/davecgh/go-spew v1.1.1
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deckarep/golang-set v1.7.1
 	github.com/docker/docker v1.13.1 // indirect
 	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect
@@ -36,7 +36,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0
-	github.com/stretchr/testify v1.4.0
+	github.com/stretchr/testify v1.4.0 // indirect
 	github.com/tektoncd/pipeline v0.10.1
 	github.com/tidwall/gjson v1.4.0
 	github.com/tidwall/pretty v1.0.1 // indirect
@@ -49,7 +49,7 @@ require (
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 	gopkg.in/yaml.v2 v2.2.8
-	gotest.tools v2.2.0+incompatible
+	gotest.tools v2.2.0+incompatible // indirect
 	k8s.io/api v0.17.0
 	k8s.io/apiextensions-apiserver v0.0.0
 	k8s.io/apimachinery v0.17.1
@@ -59,7 +59,7 @@ require (
 	k8s.io/kubernetes v1.16.2
 	k8s.io/utils v0.0.0-20191030222137-2b95a09bc58d // indirect
 	sigs.k8s.io/controller-runtime v0.4.0
-	sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/kustomize v2.0.3+incompatible // indirect
 	sigs.k8s.io/kustomize/v3 v3.2.0
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/pkg/controller/kfdef/const.go
+++ b/pkg/controller/kfdef/const.go
@@ -34,5 +34,6 @@ var (
 		{Group: "apiextensions.k8s.io", Version: "v1beta1", Kind: "CustomResourceDefinition"},
 	}
 
-	kfdefSingletonNN = types.NamespacedName{Namespace: "", Name: ""}
+	// kfdefUIDMap maps the UID to KfDef Name
+	kfdefUIDMap = map[types.UID]types.NamespacedName{}
 )

--- a/pkg/controller/kfdef/const.go
+++ b/pkg/controller/kfdef/const.go
@@ -34,5 +34,5 @@ var (
 		{Group: "apiextensions.k8s.io", Version: "v1beta1", Kind: "CustomResourceDefinition"},
 	}
 
-	kfdefSingletonNN = types.NamespacedName{}
+	kfdefSingletonNN = types.NamespacedName{Namespace: "", Name: ""}
 )


### PR DESCRIPTION
Towards #242 

This is the simpler fix for the above issue. It does following:

1. for a new kfdef instance, the kfapp directory is created as `/tmp/<namespace>/<name>`. The kfdef configuration file is copied to this directory. The cache and kustomize directories are also sub directories to this kfapp dir.

2. the manifest cache and kustomization files are downloaded and created by the same `kfApply` function like what `kfctl` command line does.

3. when a change in kfdef instance is caught, the `Reconcile` function will first remove this kfapp directory, then the same `kfApply` function runs to create/update according to the new kfdef configuration.

4. when a kubeflow resource is deleted, the same `kfApply` is run when the reconcilation kicks in. But this time, since the kfapp directory remains and the contents do not get changed, the deleted kubeflow resource will get recreated.

5. when the kfdef instance is deleted, the kfapp directory is destroyed as well.