### PR TITLE
Fixes syntax error in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ ENV PATH /go/bin:/usr/local/go/bin:/opt/google-cloud-sdk/bin:${PATH}
 # use go modules
 ENV GO111MODULE=on
 ENV GOPATH=/go
-ENV GOROOT=/usr/local/go # Workaround for https://github.com/kubernetes/gengo/issues/146
+# Workaround for https://github.com/kubernetes/gengo/issues/146
+ENV GOROOT=/usr/local/go
 
 # Create kfctl folder
 RUN mkdir -p ${GOPATH}/src/github.com/kubeflow/kfctl


### PR DESCRIPTION
## What happened

```
$ make build-builder-container
docker build \
                --build-arg GOLANG_VERSION=1.12.7 \
                --target=builder \
                --tag gcr.io/kubeflow-images-public/kfctl:v1.0-rc.3-44-gc9afc93 .
Sending build context to Docker daemon  27.87MB
Error response from daemon: failed to parse Dockerfile: Syntax error - can't find = in "#". Must be of the form: name=value
make: *** [build-builder-container] Error 1
```

## Expected result

no Syntax error when running `make build-builder-container`