### PR TITLE
Fix syncing cache behind HTTP proxy

### DIFF
--- a/pkg/kfconfig/types.go
+++ b/pkg/kfconfig/types.go
@@ -516,7 +516,9 @@ func (c *KfConfig) SyncCache() error {
 				return errors.WithStack(err)
 			}
 		} else {
-			t := &http.Transport{}
+			t := &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+			}
 			t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
 			t.RegisterProtocol("", http.NewFileTransport(http.Dir("/")))
 			hclient := &http.Client{Transport: t}


### PR DESCRIPTION
This mimics the default `RoundTripper` and it uses `http.ProxyFromEnvironment` as directed by the $HTTP_PROXY and $NO_PROXY (or $http_proxy and $no_proxy) environment variables. This allows the `Transport` to work behind a proxy.

See https://golang.org/pkg/net/http/#Transport and https://golang.org/pkg/net/http/#RoundTripper for more details.

I assume registering custom protocol is due to internal requirements as it is not necessary when downloading files from GitHub.