### PR TITLE
feat: support httpproxy in KfConfig SyncCache

### DIFF
--- a/pkg/kfconfig/types.go
+++ b/pkg/kfconfig/types.go
@@ -516,7 +516,7 @@ func (c *KfConfig) SyncCache() error {
 				return errors.WithStack(err)
 			}
 		} else {
-			t := &http.Transport{}
+			t := &http.Transport{Proxy: http.ProxyFromEnvironment}
 			t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
 			t.RegisterProtocol("", http.NewFileTransport(http.Dir("/")))
 			hclient := &http.Client{Transport: t}


### PR DESCRIPTION
I install kubeflow in my container and set up httpproxy environment variable.  

```
kfctl build -V -f ${CONFIG_URI}
```

This can download remote config file but can't download mainfests tar file.

![image](https://user-images.githubusercontent.com/7269519/82625922-0037e500-9c19-11ea-8d5f-4b5fc65af3b8.png)

So I add httpproxy support in `SyncCache`.