### PR TITLE
kfctl mirror should recourse over dependencies

### DIFF
--- a/cmd/kfctl/cmd/mirror_build.go
+++ b/cmd/kfctl/cmd/mirror_build.go
@@ -15,12 +15,16 @@ import (
 )
 
 var outputFileName string
+var directory string
 var gcb bool
 
 func init() {
 	replicateBuildCmd.Flags().StringVarP(&outputFileName, "output", "o", "",
 		`Name of the output pipeline file
 		kfctl alpha mirror build -o <name>`)
+	replicateBuildCmd.Flags().StringVarP(&directory, "directory", "d", "kustomize",
+		`The directory to search for kustomization files listing images to mirror
+		kfctl alpha mirror build -d <directory>`)
 	replicateBuildCmd.Flags().BoolVar(&gcb, "gcb", false, `Generate cloud build config`)
 	// verbose output
 	replicateBuildCmd.Flags().BoolP(string(kftypes.VERBOSE), "V", false,
@@ -57,6 +61,10 @@ Image replication rules are defined in config file.
 		if isRemoteFile {
 			return fmt.Errorf("config file path should be non-empty local file.")
 		}
+
+		if outputFileName == "" {
+			return fmt.Errorf("You must specify an output file with -o")
+		}
 		if _, err := os.Stat(configFile); err != nil {
 			return err
 		}
@@ -75,6 +83,7 @@ Image replication rules are defined in config file.
 			}
 
 		}
-		return mirror.GenerateMirroringPipeline(replication.Spec, outputFileName, gcb)
+
+		return mirror.GenerateMirroringPipeline(directory, replication.Spec, outputFileName, gcb)
 	},
 }

--- a/cmd/kfctl/cmd/root.go
+++ b/cmd/kfctl/cmd/root.go
@@ -59,7 +59,7 @@ func Execute(version string) {
 	VERSION = version
 
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Printf("kfctl exited with error: %+v", err)
 		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	k8s.io/code-generator v0.18.1 // indirect
 	k8s.io/kubernetes v1.16.2
 	sigs.k8s.io/controller-runtime v0.4.0
+	sigs.k8s.io/kustomize/kyaml v0.1.10
 	sigs.k8s.io/kustomize/v3 v3.2.0
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1393,6 +1393,8 @@ sigs.k8s.io/controller-runtime v0.2.0/go.mod h1:ZHqrRDZi3f6BzONcvlUxkqCKgwasGk5F
 sigs.k8s.io/controller-tools v0.2.2/go.mod h1:8SNGuj163x/sMwydREj7ld5mIMJu1cDanIfnx6xsU70=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
+sigs.k8s.io/kustomize/kyaml v0.1.10 h1:ZZfBnA/kYa9ZxUFIgI9oq3pWKzzA1gGOKgU0Hv/NhVg=
+sigs.k8s.io/kustomize/kyaml v0.1.10/go.mod h1:mPmeBSRy0LTMv6fSrYSoi2yIFNZVouGKDsTekE5kdhs=
 sigs.k8s.io/kustomize/kyaml v0.1.11 h1:/VvWxVIgH5gG1K4A7trgbyLgO3tRBiAWNhLFVU1HEmo=
 sigs.k8s.io/kustomize/kyaml v0.1.11/go.mod h1:72/rLkSi+L/pHM1oCjwrf3ClU+tH5kZQvvdLSqIHwWU=
 sigs.k8s.io/kustomize/v3 v3.2.0 h1:EKcEubO29vCbigcMoNynfyZH+ANWkML2UHWibt1Do7o=

--- a/pkg/mirror/mirror_image_test.go
+++ b/pkg/mirror/mirror_image_test.go
@@ -3,9 +3,11 @@ package mirror
 import (
 	"bytes"
 	mirrorv1alpha1 "github.com/kubeflow/kfctl/v3/pkg/apis/apps/imagemirror/v1alpha1"
+	"github.com/kubeflow/kfctl/v3/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"os"
+	"path"
 	"testing"
 )
 
@@ -35,7 +37,12 @@ func TestGenerateMirroringPipeline(t *testing.T) {
 		Context: "gs://kubeflow-examples/image-replicate/replicate-context.tar.gz",
 	}
 
-	if err := GenerateMirroringPipeline(spec, "pipeline.yaml", true); err != nil {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Could not get working directory; error %v", err)
+	}
+	directory := path.Join(wd, "kustomize")
+	if err := GenerateMirroringPipeline(directory, spec, "pipeline.yaml", true); err != nil {
 		t.Error(err)
 	}
 	defer func(t *testing.T) {
@@ -94,6 +101,7 @@ func compFile(cases []testCase, t *testing.T) {
 			t.Error(err)
 		}
 		if !bytes.Equal(expectedBytes, actualBytes) {
+			utils.PrintDiff(string(actualBytes), string(expectedBytes))
 			t.Errorf("Result not matching; got\n%v\nwant\n%v", string(actualBytes), string(expectedBytes))
 		}
 	}

--- a/pkg/mirror/testdata/base-pkg/kustomization.yaml
+++ b/pkg/mirror/testdata/base-pkg/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: docker.io/somerepo/image1
+  newName: docker.io/somerepo/image1
+  newTag: v0.16

--- a/pkg/mirror/testdata/expected-cloudbuild.yaml
+++ b/pkg/mirror/testdata/expected-cloudbuild.yaml
@@ -9,6 +9,7 @@ images:
 - gcr.io/kubeflow-dev/docker.io/jaegertracing/all-in-one:1.9
 - gcr.io/kubeflow-dev/docker.io/kiali/kiali:v0.16
 - gcr.io/kubeflow-dev/docker.io/prom/prometheus:v2.3.1
+- gcr.io/kubeflow-dev/docker.io/somerepo/image1:v0.16
 - gcr.io/kubeflow-dev/grafana/grafana:6.0.2
 steps:
 - args:
@@ -97,6 +98,15 @@ steps:
   - -t
   - gcr.io/kubeflow-dev/docker.io/prom/prometheus:v2.3.1
   - --build-arg=INPUT_IMAGE=docker.io/prom/prometheus:v2.3.1
+  - .
+  name: gcr.io/cloud-builders/docker
+  waitFor:
+  - '-'
+- args:
+  - build
+  - -t
+  - gcr.io/kubeflow-dev/docker.io/somerepo/image1:v0.16
+  - --build-arg=INPUT_IMAGE=docker.io/somerepo/image1:v0.16
   - .
   name: gcr.io/cloud-builders/docker
   waitFor:

--- a/pkg/mirror/testdata/expected-kustomization.yaml
+++ b/pkg/mirror/testdata/expected-kustomization.yaml
@@ -37,3 +37,4 @@ kind: Kustomization
 namespace: kubeflow
 resources:
 - istio-noauth.yaml
+- ../base-pkg

--- a/pkg/mirror/testdata/expected-pipeline.yaml
+++ b/pkg/mirror/testdata/expected-pipeline.yaml
@@ -112,7 +112,17 @@ spec:
         value: $(params.context)
       taskRef:
         name: mirror-image
-    - name: 10-grafana-grafana-6-0-2
+    - name: 10-docker-io-somerepo-image1-v0-16
+      params:
+      - name: inputImage
+        value: docker.io/somerepo/image1:v0.16
+      - name: outputImage
+        value: gcr.io/kubeflow-dev/docker.io/somerepo/image1:v0.16
+      - name: context
+        value: $(params.context)
+      taskRef:
+        name: mirror-image
+    - name: 11-grafana-grafana-6-0-2
       params:
       - name: inputImage
         value: grafana/grafana:6.0.2

--- a/pkg/mirror/testdata/kustomize/kustomization.yaml
+++ b/pkg/mirror/testdata/kustomize/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - istio-noauth.yaml
+- ../base-pkg
 namespace: kubeflow
 images:
 - name: docker.io/istio/kubectl

--- a/pkg/utils/diff.go
+++ b/pkg/utils/diff.go
@@ -1,0 +1,68 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PrintDiff pretty prints file differences.
+//
+// TODO(jlewi): We use this functionality across a lot of go packages; not just in kubeflow/kfctl but in other
+// repos like kubeflow/testing. We should think about moving it into its own go module so it can be easily reused.
+func PrintDiff(actual string, expected string) {
+	sE, maxLen := convertToArray(expected)
+	sA, _ := convertToArray(actual)
+	format := fmt.Sprintf("%%s  %%-%ds %%s\n", maxLen+4)
+	limit := 0
+	if len(sE) < len(sA) {
+		limit = len(sE)
+	} else {
+		limit = len(sA)
+	}
+	fmt.Printf(format, " ", "EXPECTED", "ACTUAL")
+	fmt.Printf(format, " ", "--------", "------")
+	for i := 0; i < limit; i++ {
+		fmt.Printf(format, hint(sE[i], sA[i]), sE[i], sA[i])
+	}
+	if len(sE) < len(sA) {
+		for i := len(sE); i < len(sA); i++ {
+			fmt.Printf(format, "X", "", sA[i])
+		}
+	} else {
+		for i := len(sA); i < len(sE); i++ {
+			fmt.Printf(format, "X", sE[i], "")
+		}
+	}
+}
+
+func tabToSpace(input string) string {
+	var result []string
+	for _, i := range input {
+		if i == 9 {
+			result = append(result, "  ")
+		} else {
+			result = append(result, string(i))
+		}
+	}
+	return strings.Join(result, "")
+}
+
+func convertToArray(x string) ([]string, int) {
+	a := strings.Split(strings.TrimSuffix(x, "\n"), "\n")
+	maxLen := 0
+	for i, v := range a {
+		z := tabToSpace(v)
+		if len(z) > maxLen {
+			maxLen = len(z)
+		}
+		a[i] = z
+	}
+	return a, maxLen
+}
+
+func hint(a, b string) string {
+	if a == b {
+		return " "
+	}
+	return "X"
+}


### PR DESCRIPTION
kfctl mirror should recourse over dependencies

* The current implementation of kfctl mirror was not looking
  at dependent packages that were out of tree. This change
  causes the mirror command to look at the resources directive
  inside the kustomization.yaml and follow those links.

  * This is necessary to support blueprints and some of the refactoring
    of the kustomize manifests intended to better support Day 2 operations.

* Fix #340 kfctl mirror shouldn't hard code the directory to search
  for images but instead allow it to be provided via a flag.
