### PR TITLE
Do not run KF E2E tests as blocking presubmits.

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -21,10 +21,12 @@ workflows:
       - pkg/*
       - testing/*
       - py/*
+  #****************************************************************************************************
+  # Per https://github.com/kubeflow/kfctl/issues/57 the following tests should not be blocking
+  # presubmits.      
   - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
     name: kfctl-go-iap
     job_types:
-      - presubmit
       - postsubmit
       - periodic
     include_dirs:
@@ -61,7 +63,6 @@ workflows:
   - py_func: kubeflow.kfctl.testing.ci.kfctl_upgrade_e2e_workflow.create_workflow
     name: kfctl-upgrade
     job_types:
-      - presubmit
       - postsubmit
       - periodic
     include_dirs:
@@ -78,31 +79,3 @@ workflows:
       test_endpoint: true
       config_path: https://raw.githubusercontent.com/kubeflow/manifests/v1.0-branch/kfdef/kfctl_gcp_iap.v1.0.0.yaml
       upgrade_spec_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_upgrade_gcp_iap_1.0.2.yaml
-  # E2E tests for kfctl_istio_dex
-  # - app_dir: kubeflow/kubeflow/testing/workflows
-  #   component: kfctl_go_test
-  #   name: kfctl-go-dex
-  #   job_types:
-  #     # Enable once we have confirmed the stability of the test
-  #     # - presubmit
-  #     # TODO(jlewi): I don't think we want to enable on presubmit.
-  #     # see https://github.com/kubeflow/kfctl/issues/57
-  #     - postsubmit
-  #     - periodic
-  #   include_dirs:
-  #     - config/*
-  #     - cmd/*
-  #     - pkg/*
-  #     - testing/*
-  #     - py/*
-  #   params:
-  #     platform: gke
-  #     gkeApiVersion: v1
-  #     workflowName: kfctl-go
-  #     useBasicAuth: false
-  #     useIstio: true
-  #     testEndpoint: false
-  #     configPath: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_istio_dex.yaml
-  #     cluster_creation_script: create_existing_cluster.sh
-  #     cluster_deletion_script: delete_existing_cluster.py
-  #     nameSuffix: dex


### PR DESCRIPTION
* Per kubeflow/kfctl#57 this removes the expensive E2E tests as blocking
presubmits. Instead of attempting to deploy Kubeflow and verify its working
we should aim to have good unittests that have a high degree of confidence.

* E2E testing of actual deployments should happen downstream and be the
  provenance of platform owners.

* The E2E tests can still run as periodic and postsubmit tests.