### PR TITLE
update operator image version for release 1.1

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -32,7 +32,7 @@ import (
 
 // Kubeflow operator version
 var (
-	Version string = "1.0.0"
+	Version string = "1.1"
 )
 
 // Change below variables to serve metrics on different host or port.

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: kubeflow-operator
           # Replace this with the built image name
-          image: aipipeline/kubeflow-operator:v1.0.0
+          image: aipipeline/kubeflow-operator:v1.1
           command:
           - kfctl
           imagePullPolicy: Always


### PR DESCRIPTION
Sync the Kubeflow operator image version with the kfctl release.