### PR TITLE
Fix the IAP endpoint_ready_test

### DIFF
--- a/py/kubeflow/kfctl/testing/util/gcp_util.py
+++ b/py/kubeflow/kfctl/testing/util/gcp_util.py
@@ -80,15 +80,10 @@ def iap_is_ready(url, wait_min=15):
     num_req += 1
     logging.info("Trying url: %s", url)
     try:
-      resp = None
       resp = make_iap_request(url, client_id, method="GET", verify=False)
-      logging.info(resp.text)
-      if resp.status_code == 200: # pylint: disable=no-else-return
-        logging.info("Endpoint is ready for %s!", url)
-        return True
-      else:
-        logging.info(
-            "%s: Endpoint not ready, request number: %s", url, num_req)
+      logging.info("Response: %s", resp)
+      logging.info("Endpoint is ready for %s!", url)
+      return True
     except Exception as e: # pylint: disable=broad-except
       logging.info("%s: Endpoint not ready, exception caught %s, request "
                    "number: %s", url, str(e), num_req)


### PR DESCRIPTION
* #355 recently changed the logic for making IAP requests to use newer libraries

* In the new code make_iap_request returns a string and not a response object
  so we need to update the calling code otherwise we get problems.

* Related to kubeflow/gcp-blueprints#51