### PR TITLE
test: test_pipeline_is_ready - fix cache-deployer deployment name

### DIFF
--- a/py/kubeflow/kfctl/testing/pytests/kf_is_ready_test.py
+++ b/py/kubeflow/kfctl/testing/pytests/kf_is_ready_test.py
@@ -105,7 +105,7 @@ def test_pipeline_is_ready(record_xml_attribute, namespace):
     "ml-pipeline-ui",
     "ml-pipeline-viewer-crd",
     "ml-pipeline-visualizationserver",
-    "cache-deployer",
+    "cache-deployer-deployment",
     "cache-server",
   ]
   check_deployments_ready(record_xml_attribute, namespace,


### PR DESCRIPTION
pipeline is ready test still failing: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/kubeflow-gcp-blueprints-master-periodic/1280342456545579010

ref: https://github.com/kubeflow/pipelines/blob/bd0f4d23b9e73082a3924d9f3869bbe537639557/manifests/kustomize/base/cache-deployer/cache-deployer-deployment.yaml#L4

cache deployer deployment should have a suffix

/assign @jlewi 

part of https://github.com/kubeflow/gcp-blueprints/issues/59