### PR TITLE
Improve AWS kfctl

### DIFF
--- a/pkg/kfapp/aws/aws.go
+++ b/pkg/kfapp/aws/aws.go
@@ -454,10 +454,6 @@ func (aws *Aws) Generate(resources kftypes.ResourceEnum) error {
 		return errors.WithStack(err)
 	}
 
-	if err := aws.kfDef.SetApplicationParameter("istio-ingress", "namespace", IstioNamespace); err != nil {
-		return errors.WithStack(err)
-	}
-
 	if pluginSpec.Auth != nil && pluginSpec.Auth.BasicAuth != nil && pluginSpec.Auth.BasicAuth.Password != "" {
 		if err := aws.kfDef.SetApplicationParameter("dex", "static_email", pluginSpec.Auth.BasicAuth.Username); err != nil {
 			return errors.WithStack(err)


### PR DESCRIPTION
### What change we make:

1. Deleted legacy code in `aws.go`

2. Since `github.com/kubernetes-sigs/application` deleted tag `v0.8.0` (https://github.com/kubernetes-sigs/application/tags), upgrade to `v0.8.1`.

### What test we run:
Run `make build` and it succeeded, then use new-built kfctl to deploy kubeflow and passed.