### PR TITLE
Use istio-parameter in manifests

### DIFF
--- a/pkg/kfapp/aws/aws.go
+++ b/pkg/kfapp/aws/aws.go
@@ -467,10 +467,6 @@ func (aws *Aws) Generate(resources kftypes.ResourceEnum) error {
 		}
 	} else {
 		if pluginSpec.Auth.Cognito != nil {
-			if err := aws.kfDef.SetApplicationParameter("istio", "clusterRbacConfig", "ON"); err != nil {
-				return errors.WithStack(err)
-			}
-
 			if err := aws.kfDef.SetApplicationParameter("istio-ingress", "CognitoUserPoolArn", pluginSpec.Auth.Cognito.CognitoUserPoolArn); err != nil {
 				return errors.WithStack(err)
 			}

--- a/pkg/kfconfig/types.go
+++ b/pkg/kfconfig/types.go
@@ -844,7 +844,7 @@ func (c *KfConfig) SetApplicationParameter(appName string, paramName string, val
 			"spartakus":                  "spartakus",
 			// AWS Specific
 			"aws-alb-ingress-controller": KfAppsStackName,
-			"istio-ingress":              KfAppsStackName,
+			"istio-ingress":              "istio-ingress",
 		}
 
 		appNameDir, ok := appToStack[appName]


### PR DESCRIPTION
For now, `istio` component has not moved to V3 yet. Thus, it still use `istio-parameter` rather than `istio-config`.

On kfctl side, we have to use `istio-parameter` now in V3 changes.

Will roll back until `istio` moved to V3.