### PR TITLE
Add Jeffwan as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@ approvers:
   - adrian555
   - animeshsingh
   - crobby
+  - Jeffwan
   - vpavlin
   - yanniszark
 reviewers:


### PR DESCRIPTION
Here's the contributions.
https://github.com/kubeflow/kfctl/pulls/Jeffwan


We (AWS) still uses kfctl to install Kubeflow in 1.1 version, probably 1.2 and future versions as well. 
I would like to put more efforts to help improve experiences for kfctl users. 

I am trying to apply for approver to help community features and requests.

