### PR TITLE
Create a kustomize function to set the gateway on virtual services.     

### DIFF
--- a/kustomize-fns/image-prefix/function.go
+++ b/kustomize-fns/image-prefix/function.go
@@ -4,7 +4,6 @@ package image_prefix
 import (
 	"fmt"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"os"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"strings"
 
@@ -99,8 +98,6 @@ func (f *ImagePrefixFunction) Filter(inputs []*yaml.RNode) ([]*yaml.RNode, error
 // replaceImage looks for an annotation changing docker image prefixes and if it is present
 // applies it to all the images.
 func (f *ImagePrefixFunction) replaceImage(r *yaml.RNode) error {
-	m , _  := r.GetMeta()
-	fmt.Fprintf(os.Stderr, "Meta %+v",m)
 	// lookup the containers field
 	containers, err := r.Pipe(yaml.Lookup("spec", "template", "spec", "containers"))
 	if err != nil {

--- a/kustomize-fns/latest_image.json
+++ b/kustomize-fns/latest_image.json
@@ -1,0 +1,1 @@
+{"builds":[{"imageName":"gcr.io/kubeflow-images-public/kpt-fns","tag":"gcr.io/kubeflow-images-public/kpt-fns:v1.1-rc.0-22-gbb803bc@sha256:23c586b7df3603bcf6610e8089acfe03956473cd4d367bbc05270bba74dc29fd"}]}

--- a/kustomize-fns/main.go
+++ b/kustomize-fns/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	ip "github.com/kubeflow/kfctl/kustomize-fns/image-prefix"
 	rn "github.com/kubeflow/kfctl/kustomize-fns/remove-namespace"
+	vs "github.com/kubeflow/kfctl/kustomize-fns/virtual-service"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"io"
@@ -111,6 +112,7 @@ func (d *Dispatcher) run(input io.Reader) error {
 var dispatchTable = map[string]func() kio.Filter{
 	ip.Kind: ip.Filter,
 	rn.Kind: rn.Filter,
+	vs.Kind: vs.Filter,
 }
 
 func (d *Dispatcher) Filter(inputs []*yaml.RNode) ([]*yaml.RNode, error) {

--- a/kustomize-fns/remove-namespace/function.go
+++ b/kustomize-fns/remove-namespace/function.go
@@ -143,7 +143,6 @@ func getGroup(apiVersion string) string {
 // remove namespace from cluster resources.
 func (f *RemoveNamespaceFunction) removeNamespace(r *yaml.RNode) error {
 
-	// check for the tshirt-size annotations
 	meta, err := r.GetMeta()
 	if err != nil {
 		return err

--- a/kustomize-fns/virtual-service/function.go
+++ b/kustomize-fns/virtual-service/function.go
@@ -1,0 +1,112 @@
+// Package virtual_service implements a kustomize function for configuring virtual services
+package virtual_service
+
+import (
+	"fmt"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+const (
+	Kind       = "VirtualServiceTransform"
+	APIVersion = "kubeflow.org/v1alpha1"
+	VSKind     = "VirtualService"
+)
+
+var _ kio.Filter = &VirtualServiceFunction{}
+
+// Filter returns a new VirtualServiceFunction
+func Filter() kio.Filter {
+	return &VirtualServiceFunction{}
+}
+
+// VirtualServiceFunction implements the ImagePrefix Function
+type VirtualServiceFunction struct {
+	// Kind is the API name.  Must be ImagePrefix.
+	Kind string `yaml:"kind"`
+
+	// APIVersion is the API version.  Must be examples.kpt.dev/v1alpha1
+	APIVersion string `yaml:"apiVersion"`
+
+	// Metadata defines instance metadata.
+	Metadata Metadata `yaml:"metadata"`
+
+	// Spec defines the desired declarative configuration.
+	Spec Spec `yaml:"spec"`
+}
+
+type Metadata struct {
+	// Name is the name of the ImagePrefix Resources
+	Name string `yaml:"name"`
+
+	// Namespace is the namespace of the ImagePrefix Resources
+	Namespace string `yaml:"namespace"`
+
+	// Labels are labels applied to the ImagePrefix Resources
+	Labels map[string]string `yaml:"labels"`
+
+	// Annotations are annotations applied to the ImagePrefix Resources
+	Annotations map[string]string `yaml:"annotations"`
+}
+
+type Spec struct {
+	// Gateway is the gateway to use for all virtual services
+	Gateway string `yaml:"gateway"`
+}
+
+func (f *VirtualServiceFunction) init() error {
+	if f.Metadata.Name == "" {
+		return fmt.Errorf("must specify %v name", Kind)
+	}
+
+	if f.Metadata.Labels == nil {
+		f.Metadata.Labels = map[string]string{}
+	}
+
+	return nil
+}
+
+// Filter looks for virtual services and sets the gateway on them.
+func (f *VirtualServiceFunction) Filter(inputs []*yaml.RNode) ([]*yaml.RNode, error) {
+	if err := f.init(); err != nil {
+		return nil, err
+	}
+
+	errors := []error{}
+
+	for _, r := range inputs {
+		if err := f.setGateway(r); err != nil {
+			errors = append(errors, err)
+		}
+	}
+	return inputs, utilerrors.NewAggregate(errors)
+}
+
+// setGateway sets the gateway on virtual services
+func (f *VirtualServiceFunction) setGateway(r *yaml.RNode) error {
+	meta, err := r.GetMeta()
+	if err != nil {
+		return err
+	}
+
+	if meta.Kind != VSKind {
+		// Not a virtual service; skip this resource
+		return nil
+	}
+
+	value, err := yaml.Parse(fmt.Sprintf("[%s]", f.Spec.Gateway))
+
+	if err != nil {
+		return err
+
+	}
+	return r.PipeE(
+		yaml.LookupCreate(yaml.ScalarNode, "spec"),
+		yaml.FieldSetter{
+			Name:  "gateways",
+			Value: value,
+		},
+	)
+}

--- a/kustomize-fns/virtual-service/function_test.go
+++ b/kustomize-fns/virtual-service/function_test.go
@@ -1,0 +1,130 @@
+package virtual_service
+
+import (
+	"bytes"
+	"github.com/kubeflow/kfctl/kustomize-fns/utils"
+	"github.com/pkg/errors"
+	"io/ioutil"
+	"os"
+	"path"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+	"testing"
+)
+
+func readYaml(path string) ([]*yaml.RNode, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error reading path %v", path)
+	}
+
+	input := bytes.NewReader(data)
+	reader := kio.ByteReader{
+		Reader: input,
+		// We need to disable adding reader annotations because
+		// we want to run some checks about whether annotations are set and
+		// adding those annotations interferes with that.
+		OmitReaderAnnotations: true,
+	}
+
+	nodes, err := reader.Read()
+
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error unmarshaling %v", path)
+	}
+
+	return nodes, nil
+}
+
+func writeYaml(nodes []*yaml.RNode) ([]byte, error) {
+	var b bytes.Buffer
+	writer := kio.ByteWriter{
+		Writer: &b,
+	}
+
+	if err := writer.Write(nodes); err != nil {
+		return []byte{}, err
+	}
+
+	return b.Bytes(), nil
+}
+
+func Test_set_gateway(t *testing.T) {
+
+	type testCase struct {
+		InputFile    string
+		ExpectedFile string
+	}
+
+	cwd, err := os.Getwd()
+
+	if err != nil {
+		t.Fatalf("Error getting current directory; error %v", err)
+	}
+
+	testDir := path.Join(cwd, "test_data")
+
+	cases := []testCase{
+		{
+			InputFile:    path.Join(testDir, "input.yaml"),
+			ExpectedFile: path.Join(testDir, "expected.yaml"),
+		},
+	}
+
+	f := &VirtualServiceFunction {
+			Spec: Spec{
+				Gateway: "namespace/new-gateway",
+			},
+		}
+
+	for _, c := range cases {
+		nodes, err := readYaml(c.InputFile)
+
+		if err != nil {
+			t.Errorf("Error reading YAML: %v", err)
+		}
+
+		if len(nodes) != 1 {
+			t.Errorf("Expected 1 node in file %v", c.InputFile)
+		}
+		node := nodes[0]
+
+		err = f.setGateway(node)
+		if err != nil {
+			t.Errorf("setGateway failed; error %v", err)
+			continue
+		}
+
+		b, err := writeYaml([]*yaml.RNode{node})
+
+		if err != nil {
+			t.Errorf("Error writing yaml; error %v", err)
+			continue
+		}
+
+		actual := string(b)
+
+
+		// read the expected yaml and then rewrites using kio.ByteWriter.
+		// We do this because ByteWriter makes some formatting decisions and we
+		// we want to apply the same formatting to the expected values
+
+		eNode, err := readYaml(c.ExpectedFile)
+
+		if err != nil {
+			t.Errorf("Could not read expected file %v; error %v", c.ExpectedFile, err)
+		}
+
+		eBytes, err := writeYaml(eNode)
+
+		if err != nil {
+			t.Errorf("Could not format expected file %v; error %v", c.ExpectedFile, err)
+		}
+
+		expected := string(eBytes)
+
+		if actual != expected {
+			utils.PrintDiff(actual, expected)
+		}
+	}
+}

--- a/kustomize-fns/virtual-service/test_data/expected.yaml
+++ b/kustomize-fns/virtual-service/test_data/expected.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  labels:
+    kustomize.component: profiles
+  name: profiles-kfam
+  namespace: kubeflow
+spec:
+  gateways:
+  - namespace/new-gateway
+  hosts:
+  - '*'
+  http:
+  - headers:
+      request:
+        add:
+          x-forwarded-prefix: /kfam
+    match:
+    - uri:
+        prefix: /kfam/
+    rewrite:
+      uri: /kfam/
+    route:
+    - destination:
+        host: profiles-kfam.kubeflow.svc.cluster.local
+        port:
+          number: 8081

--- a/kustomize-fns/virtual-service/test_data/input.yaml
+++ b/kustomize-fns/virtual-service/test_data/input.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  labels:
+    kustomize.component: profiles
+  name: profiles-kfam
+  namespace: kubeflow
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - headers:
+      request:
+        add:
+          x-forwarded-prefix: /kfam
+    match:
+    - uri:
+        prefix: /kfam/
+    rewrite:
+      uri: /kfam/
+    route:
+    - destination:
+        host: profiles-kfam.kubeflow.svc.cluster.local
+        port:
+          number: 8081


### PR DESCRIPTION
* The gateway on our virtual services is misconfigured as described in
  kubeflow/gcp-blueprints#22 and kubeflow/manifests#1169

  * We should be using the istio gateway in the istio namespace and not
    the gateway in the kubeflow namespace

* To begin to fix that this pr adds a kustomize function to transform
  all the gateways in the virtual services. This makes it possible for
  configurations to start transitioning to the gateway in the istio namespace

 * We need this for GCP blueprints with ACM (kubeflow/gcp-blueprints#22)
   because we don't want to duplicate the gateway in that case.

* Clean up some comments in the existing kustomize functions.