### PR TITLE
Remove jlewi@ from the root OWNERs file.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,6 @@ approvers:
   - adrian555
   - animeshsingh
   - crobby
-  - jlewi
   - vpavlin
   - yanniszark
 reviewers:


### PR DESCRIPTION
I'm no longer involved in the day to day development of kfctl

* On GCP we are no longer using kfctl except in some rare edge cases. We are increasingly using the kustomize-fns but there is
  a more narrowly scoped OWNERs file for that.