### PR TITLE
Fix build error for int to string conversion (#396)

### DIFF
--- a/pkg/kfapp/aws/aws.go
+++ b/pkg/kfapp/aws/aws.go
@@ -561,7 +561,7 @@ func (aws *Aws) Generate(resources kftypes.ResourceEnum) error {
 		}
 
 		if pluginSpec.ManagedRelationDatabase.Port != nil {
-			if err := aws.kfDef.SetApplicationParameter("metadata", "MYSQL_PORT", string(*pluginSpec.ManagedRelationDatabase.Port)); err != nil {
+			if err := aws.kfDef.SetApplicationParameter("metadata", "MYSQL_PORT", fmt.Sprint(*pluginSpec.ManagedRelationDatabase.Port)); err != nil {
 				return errors.WithStack(err)
 			}
 		}


### PR DESCRIPTION
Fixes build issue

```
pkg/kfapp/aws/aws.go:564:74: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
```

Fixed as suggested, sinc the result should be string with the actual port number.