### PR TITLE
Add USER-AGENT header in Github tarball retrieving

### DIFF
--- a/pkg/kfconfig/types.go
+++ b/pkg/kfconfig/types.go
@@ -531,7 +531,9 @@ func (c *KfConfig) SyncCache() error {
 			t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
 			t.RegisterProtocol("", http.NewFileTransport(http.Dir("/")))
 			hclient := &http.Client{Transport: t}
-			resp, err := hclient.Get(r.URI)
+			req, _ := http.NewRequest("GET", r.URI, nil)
+			req.Header.Set("User-Agent", "kfctl")
+			resp, err := hclient.Do(req)
 			if err != nil {
 				return &kfapis.KfError{
 					Code:    int(kfapis.INVALID_ARGUMENT),


### PR DESCRIPTION
Resolve this. https://github.com/kubeflow/kubeflow/issues/5245

Seems some corp network has restrictions on the requests. Setting dedicate `user-agent` solve the problem.
It would be better to include kfctl version here. However, version is in `cmd` package and if we import it, we will see error like beflow. We can leave it to `kfctl` at this moment since no server side application need that information

```
../../pkg/kfconfig/types.go:10:2: import "github.com/kubeflow/kfctl/v3/cmd/kfctl" is a program, not an importable package
import cycle not allowed
package main
    imports github.com/kubeflow/kfctl/v3/cmd/kfctl/cmd
    imports github.com/kubeflow/kfctl/v3/pkg/kfapp/coordinator
    imports github.com/kubeflow/kfctl/v3/pkg/kfapp/aws
    imports github.com/kubeflow/kfctl/v3/pkg/kfconfig
    imports github.com/kubeflow/kfctl/v3/cmd/kfctl
    imports github.com/kubeflow/kfctl/v3/cmd/kfctl/cmd
```