### PR TITLE
Add PatrickXYS as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,10 +3,10 @@ approvers:
   - animeshsingh
   - crobby
   - Jeffwan
+  - PatrickXYS
   - vpavlin
   - yanniszark
 reviewers:
   - adrian555
   - pdmack
   - tomcli
-  - PatrickXYS


### PR DESCRIPTION
I've continuously working on kfctl and AWS will be supporting kfctl if there's no breaking change, 

meanwhile, we'll help community bring back kfctl + manifest E2E test which consumes AWS resources.

Here is my contribution list:

https://github.com/kubeflow/kfctl/pulls/PatrickXYS

