### PR TITLE
Test against k8s python-client version 12.0

### DIFF
--- a/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
+++ b/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
@@ -295,7 +295,7 @@ class Builder(object):
         {"name": "TEST_TARGET_NAME",
          "value": self.test_target_name},
        ],
-      'image': '527798164940.dkr.ecr.us-west-2.amazonaws.com/aws-kubeflow-ci/test-worker:latest',
+      'image': '527798164940.dkr.ecr.us-west-2.amazonaws.com/aws-kubeflow-ci/test-worker:v1.2-branch',
       'imagePullPolicy': 'Always',
       'name': '',
       'resources': {'limits': {'cpu': '4', 'memory': '4Gi'},
@@ -431,7 +431,7 @@ class Builder(object):
     self.workflow = self._build_workflow()
     task_template = self._build_task_template()
     py3_template = argo_build_util.deep_copy(task_template)
-    py3_template["container"]["image"] = "527798164940.dkr.ecr.us-west-2.amazonaws.com/aws-kubeflow-ci/test-worker:latest"
+    py3_template["container"]["image"] = "527798164940.dkr.ecr.us-west-2.amazonaws.com/aws-kubeflow-ci/test-worker:v1.2-branch"
     default_namespace = "kubeflow"
 
     #**************************************************************************


### PR DESCRIPTION
Per discussion in the issue https://github.com/kubeflow/testing/issues/779, we plan to upgrade kubernetes python-client version from 9.0 to 12.0 to utilize new API. 

Kick off test in this PR to see if works fine
