### PR TITLE
Remove autoscaler-hpa knative deployment check

### DIFF
--- a/py/kubeflow/kfctl/testing/pytests/kf_is_ready_test.py
+++ b/py/kubeflow/kfctl/testing/pytests/kf_is_ready_test.py
@@ -214,7 +214,6 @@ def test_kf_is_ready(record_xml_attribute, namespace, use_basic_auth,
     knative_related_deployments = [
         "activator",
         "autoscaler",
-        "autoscaler-hpa",
         "controller",
         "networking-istio",
         "webhook",


### PR DESCRIPTION
In anticipation of an update of the manifest knative versionto v0.14.3, this PR removes a check for the autoscaler-hpa deployment which was removed. See: https://github.com/kubeflow/manifests/pull/1617 where the test is failing checking for a nonexistent deployment.