### PR TITLE
Add configuration for eks_cluster_version

### DIFF
--- a/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
+++ b/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
@@ -74,10 +74,10 @@ class Builder(object):
                use_basic_auth=False,
                build_and_apply=False,
                test_target_name=None,
+               eks_cluster_version="1.17",
                extra_repos="",
                **kwargs):
     """Initialize a builder.
-
     Args:
       name: Name for the workflow.
       namespace: Namespace for the workflow.
@@ -156,6 +156,9 @@ class Builder(object):
 
     # Name for ephemeral EKS cluster
     self.cluster_name = "eks-cluster-" + self.uuid
+
+    # Version for ephemeral EKS clsuter
+    self.eks_cluster_version = eks_cluster_version
 
     # Config name is the name of the config file. This is used to give junit
     # files unique names.
@@ -526,6 +529,7 @@ class Builder(object):
         # Failures still appear to be captured and stored in the junit file.
         "-s",
         "--cluster_name=" + self.cluster_name,
+        "--eks_cluster_version=" + str(self.eks_cluster_version),
         # Embedded Script in the ECR Image
         "--cluster_creation_script=" + "/usr/local/bin/create-eks-cluster.sh",
         "--values=" + self.values_str,
@@ -667,7 +671,6 @@ class Builder(object):
 # let e2e_tool take care of this.
 def create_workflow(**kwargs): # pylint: disable=too-many-statements
   """Create workflow returns an Argo workflow to test kfctl upgrades.
-
   Args:
     name: Name to give to the workflow. This can also be used to name things
      associated with the workflow.

--- a/py/kubeflow/kfctl/testing/pytests/conftest.py
+++ b/py/kubeflow/kfctl/testing/pytests/conftest.py
@@ -56,6 +56,10 @@ def pytest_addoption(parser):
       help="Use istio.")
 
   parser.addoption(
+      "--eks_cluster_version", action="store", default="",
+      help="Version of ephemeral EKS cluster")
+
+  parser.addoption(
       "--cluster_creation_script", action="store", default="",
       help="The script to use to create a K8s cluster before running kfctl.")
 
@@ -104,6 +108,10 @@ def config_path(request):
 @pytest.fixture
 def values(request):
   return request.config.getoption("--values")
+
+@pytest.fixture
+def eks_cluster_version(request):
+  return request.config.getoption("--eks_cluster_version")
 
 @pytest.fixture
 def cluster_creation_script(request):

--- a/py/kubeflow/kfctl/testing/pytests/kfctl_create_cluster_test.py
+++ b/py/kubeflow/kfctl/testing/pytests/kfctl_create_cluster_test.py
@@ -4,11 +4,11 @@ import os
 from kubeflow.testing import util
 
 
-def test_create_cluster(record_xml_attribute, cluster_name, cluster_creation_script, values):
+def test_create_cluster(record_xml_attribute, cluster_name, eks_cluster_version, cluster_creation_script, values):
   """Test Create Cluster For E2E Test.
-
   Args:
     cluster_name: Name of EKS cluster
+    eks_cluster_version: Version of EKS cluster
     cluster_creation_script: script invoked to create a new cluster
     values: Comma separated list of variables to substitute into config_path
   """
@@ -24,6 +24,7 @@ def test_create_cluster(record_xml_attribute, cluster_name, cluster_creation_scr
   # Create EKS Cluster
   logging.info("Creating EKS Cluster")
   os.environ["CLUSTER_NAME"] = cluster_name
+  os.environ["EKS_CLUSTER_VERSION"] = eks_cluster_version
   util.run(["/bin/bash", "-c", cluster_creation_script])
 
 


### PR DESCRIPTION
To establish Kubeflow - Kubernetes compatibility matrix, add configuration for `eks_cluster_version`,

meanwhile set up presubmit test for 1.15 - 1.18 EKS cluster. 

/hold 

Hold until test succeed, technically we won't need to change kfctl's `prow_config.yaml` but in manifests `prow_config.yaml`