### PR TITLE
Fixed the default output to point to `1.2` instead of `1.0`

### DIFF
--- a/cmd/kfctl/cmd/apply.go
+++ b/cmd/kfctl/cmd/apply.go
@@ -35,10 +35,10 @@ var kubeContext = ""
 
 // KFDef example configs to be printed out from apply --help
 const (
-	awsConfig      = "https://raw.githubusercontent.com/kubeflow/manifests/v1.0-branch/kfdef/kfctl_aws.v1.0.0.yaml"
+	awsConfig      = "https://raw.githubusercontent.com/kubeflow/manifests/v1.2-branch/kfdef/kfctl_aws.v1.2.0.yaml"
 	gcpConfig      = "https://raw.githubusercontent.com/kubeflow/manifests/v1.0-branch/kfdef/kfctl_gcp_iap.v1.0.0.yaml"
-	istioDexConfig = "https://raw.githubusercontent.com/kubeflow/manifests/v1.0-branch/kfdef/kfctl_istio_dex.v1.0.0.yaml"
-	k8sConfig      = "https://raw.githubusercontent.com/kubeflow/manifests/v1.0-branch/kfdef/kfctl_k8s_istio.v1.0.0.yaml"
+	istioDexConfig = "https://raw.githubusercontent.com/kubeflow/manifests/v1.2-branch/kfdef/kfctl_istio_dex.v1.2.0.yaml"
+	k8sConfig      = "https://raw.githubusercontent.com/kubeflow/manifests/v1.2-branch/kfdef/kfctl_k8s_istio.v1.2.0.yaml"
 )
 
 // applyCmd represents the apply command


### PR DESCRIPTION
The default command line output was still pointing to `1.0`. 

I updated it to point to `1.2` to the latest version. 

I couldn't find an update for `1.2` for this `	gcpConfig      = "https://raw.githubusercontent.com/kubeflow/manifests/v1.0-branch/kfdef/kfctl_gcp_iap.v1.0.0.yaml"`