### PR TITLE
Added support for IBM Power CPU architecture (ppc64le) and minor sche…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ VERBOSE ?=
 PLUGINS_ENVIRONMENT ?= $(GOPATH)/src/github.com/kubeflow/kfctl/bin
 export GO111MODULE = on
 export GO = go
-ARCH ?= $(shell ${GO} env|grep GOOS|cut -d'=' -f2|tr -d '"')
+OS ?= $(shell ${GO} env|grep GOOS|cut -d'=' -f2|tr -d '"')
+ARCH ?= $(shell ${GO} env|grep GOARCH|cut -d'=' -f2|tr -d '"')
 OPERATOR_IMG ?= kubeflow-operator
 IMAGE_BUILDER ?= docker
 DOCKERFILE ?= Dockerfile
@@ -126,24 +127,27 @@ build: build-kfctl
 
 build-kfctl: deepcopy generate fmt vet
 	# TODO(swiftdiaries): figure out import conflict errors for windows
-	#CGO_ENABLED=0 GOOS=windows GOARCH=amd64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/windows/kfctl.exe cmd/kfctl/main.go
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=${TAG}" -o bin/darwin/kfctl cmd/kfctl/main.go
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/linux/kfctl cmd/kfctl/main.go
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/arm64/kfctl cmd/kfctl/main.go
-	cp bin/$(ARCH)/kfctl bin/kfctl
+	#CGO_ENABLED=0 GOOS=windows GOARCH=amd64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/windows_amd64/kfctl.exe cmd/kfctl/main.go
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=${TAG}" -o bin/darwin_amd64/kfctl cmd/kfctl/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/linux_amd64/kfctl cmd/kfctl/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/linux_arm64/kfctl cmd/kfctl/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/linux_ppc64le/kfctl cmd/kfctl/main.go
+	cp bin/${OS}_$(ARCH)/kfctl bin/kfctl
 
 # Fast rebuilds useful for development.
 # Does not regenerate code; assumes you already ran build-kfctl once.
 build-kfctl-fast: fmt vet
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/linux/kfctl cmd/kfctl/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/linux_amd64/kfctl cmd/kfctl/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le ${GO} build -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" -o bin/linux_ppc64le/kfctl cmd/kfctl/main.go
 
 # Release tarballs suitable for upload to GitHub release pages
 build-kfctl-tgz: build-kfctl
 	chmod a+rx ./bin/kfctl
 	rm -f bin/*.tgz
-	cd bin/linux && tar -cvzf kfctl_$(TAG)_linux.tar.gz ./kfctl
-	cd bin/darwin && tar -cvzf kfctl_${TAG}_darwin.tar.gz ./kfctl
-	cd bin/arm64 && tar -cvzf kfctl_${TAG}_arm64.tar.gz ./kfctl
+	cd bin/linux_amd64 && tar -cvzf kfctl_$(TAG)_linux_amd64.tar.gz ./kfctl
+	cd bin/darwin_amd64 && tar -cvzf kfctl_${TAG}_darwin_amd64.tar.gz ./kfctl
+	cd bin/linux_arm64 && tar -cvzf kfctl_${TAG}_linux_arm64.tar.gz ./kfctl
+	cd bin/linux_ppc64le && tar -cvzf kfctl_${TAG}_linux_ppc64le.tar.gz ./kfctl
 
 build-and-push-operator: build-operator push-operator
 build-push-update-operator: build-operator push-operator update-operator-image
@@ -189,28 +193,34 @@ update-operator-image:
 # push the releases to a GitHub page
 push-to-github-release: build-kfctl-tgz
 	github-release upload \
-	    --user kubeflow \
-	    --repo kubeflow \
-	    --tag $(TAG) \
-	    --name "kfctl_$(TAG)_linux.tar.gz" \
-	    --file bin/linux/kfctl_$(TAG)_linux.tar.gz
+		--user kubeflow \
+		--repo kubeflow \
+		--tag $(TAG) \
+		--name "kfctl_$(TAG)_linux_amd64.tar.gz" \
+		--file bin/linux_amd64/kfctl_$(TAG)_linux_amd64.tar.gz
 	github-release upload \
-	    --user kubeflow \
-	    --repo kubeflow \
-	    --tag $(TAG) \
-	    --name "kfctl_$(TAG)_darwin.tar.gz" \
-	    --file bin/darwin/kfctl_$(TAG)_darwin.tar.gz
+		--user kubeflow \
+		--repo kubeflow \
+		--tag $(TAG) \
+		--name "kfctl_$(TAG)_darwin_amd64.tar.gz" \
+		--file bin/darwin_amd64/kfctl_$(TAG)_darwin_amd64.tar.gz
 	github-release upload \
-            --user kubeflow \
-            --repo kubeflow \
-            --tag $(TAG) \
-            --name "kfctl_$(TAG)_arm64.tar.gz" \
-            --file bin/arm64/kfctl_$(TAG)_arm64.tar.gz
+		--user kubeflow \
+		--repo kubeflow \
+		--tag $(TAG) \
+		--name "kfctl_$(TAG)_linux_arm64.tar.gz" \
+		--file bin/linux_arm64/kfctl_$(TAG)_linux_arm64.tar.gz
+	github-release upload \
+		--user kubeflow \
+		--repo kubeflow \
+		--tag $(TAG) \
+		--name "kfctl_$(TAG)_linux_ppc64le.tar.gz" \
+		--file bin/linux_ppc64le/kfctl_$(TAG)_linux_ppc64le.tar.gz
 
 build-kfctl-container:
 	DOCKER_BUILDKIT=1 docker build \
-                --build-arg REPO="$(REPO)" \
-                --build-arg BRANCH=$(BRANCH) \
+		--build-arg REPO="$(REPO)" \
+		--build-arg BRANCH=$(BRANCH) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg VERSION=$(TAG) \
 		--target=$(KFCTL_TARGET) \


### PR DESCRIPTION
…ma fixes

- ARCH variable was a little bit misleading as it was actually returning the OS, therefore renamed and added ARCH

- For build-kfctl, build-kfctl-tgz and push-to-github-release added ppc64le ARCH + updated schema which follows $OS_$ARCH (was mixed before - sometimes linux/darwin as OS and arm64 as ARCH type)