### PR TITLE
Use Github Action for kfctl unit test

### DIFF
--- a/.github/workflows/kfctl_go_unittests.yaml
+++ b/.github/workflows/kfctl_go_unittests.yaml
@@ -1,0 +1,18 @@
+name: Unit Test
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v2
+
+    - name: Unit Test
+      run: |
+        go test ./... -v 2>&1

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -6,16 +6,16 @@ python_paths:
   - kubeflow/testing/py
   - kubeflow/kfctl/py
 workflows:
-  - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
-    name: kfctl-e2e
-    job_types:
-     - presubmit
-     - periodic
-    include_dirs:
-      - config/*
-      - cmd/*
-      - pkg/*
-      - py/*
-    kwargs:
-      build_and_apply: false
-      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_istio_dex.yaml
+#  - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
+#    name: kfctl-e2e
+#    job_types:
+#     - presubmit
+#     - periodic
+#    include_dirs:
+#      - config/*
+#      - cmd/*
+#      - pkg/*
+#      - py/*
+#    kwargs:
+#      build_and_apply: false
+#      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_istio_dex.yaml

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -6,16 +6,16 @@ python_paths:
   - kubeflow/testing/py
   - kubeflow/kfctl/py
 workflows:
-#  - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
-#    name: kfctl-e2e
-#    job_types:
-#     - presubmit
-#     - periodic
-#    include_dirs:
-#      - config/*
-#      - cmd/*
-#      - pkg/*
-#      - py/*
-#    kwargs:
-#      build_and_apply: false
-#      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_istio_dex.yaml
+  - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
+    name: kfctl-e2e
+    job_types:
+     - presubmit
+     - periodic
+    include_dirs:
+      - config/*
+      - cmd/*
+      - pkg/*
+      - py/*
+    kwargs:
+      build_and_apply: false
+      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_istio_dex.yaml

--- a/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
+++ b/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
@@ -520,26 +520,6 @@ class Builder(object):
     build_kfctl = self._build_step(step_name, self.workflow, E2E_DAG_NAME,
                                    py3_template, command, dependences)
 
-    #***************************************************************************
-    # kfctl go unit tests
-    #***************************************************************************
-    step_name = "kfctl-go-unittests"
-    command = ["make",
-               "go-unittests-junit",
-               "JUNIT_DIR=" + self.artifacts_dir,
-               "JUNIT_FILE=" + self.artifacts_dir + "/junit_go-kfctl-unit-tests.xml",
-               ]
-
-    dependences = [checkout["name"]]
-    # Temporarily change workingDir to kubeflow/kfctl
-    task_template["container"]["workingDir"] = os.path.join(
-      self.src_dir)
-    kfctl_go_unittests = self._build_step(step_name, self.workflow, E2E_DAG_NAME,
-                                   task_template, command, dependences)
-    # Roll back workingDir
-    task_template["container"]["workingDir"] = os.path.join(
-      self.kfctl_pytest_dir)
-
     #**************************************************************************
     # Create EKS cluster for E2E test
     step_name = "kfctl-create-cluster"
@@ -597,7 +577,7 @@ class Builder(object):
         "--kfctl_repo_path=" + self.src_dir,
     ]
 
-    dependences = [build_kfctl["name"], create_cluster["name"], symlink["name"], kfctl_go_unittests["name"]]
+    dependences = [build_kfctl["name"], create_cluster["name"], symlink["name"]]
     deploy_kf = self._build_step(step_name, self.workflow, E2E_DAG_NAME,
                                    py3_template, command, dependences)
 


### PR DESCRIPTION
Use Github Action for kfctl unit test instead

This can help E2E tests become too flaky and increase stability as well.