### PR TITLE
Disable kfctl e2e test because current manifests repo refactoring

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -1,5 +1,5 @@
-# This file configures the workflows to trigger in our Prow jobs.
-# see kubeflow/testing/py/run_e2e_workflow.py
+## This file configures the workflows to trigger in our Prow jobs.
+## see kubeflow/testing/py/run_e2e_workflow.py
 python_paths:
   # Need to place kubeflow/testing in front of kubeflow/testing so that the package can
   # be correctly located.
@@ -9,7 +9,6 @@ workflows:
   - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
     name: kfctl-e2e
     job_types:
-     - presubmit
      - periodic
     include_dirs:
       - config/*

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -9,6 +9,9 @@ workflows:
   - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
     name: kfctl-e2e
     job_types:
+     # Disable presubmit E2E test because large refactoring in manifests repo
+     # Details can be found https://github.com/kubeflow/manifests/pull/1719
+     # - presubmit
      - periodic
     include_dirs:
       - config/*


### PR DESCRIPTION
Since there will be large refactoring work in kubeflow/manifests repo, results in master branch's manifest fail to work, thus, disable kfctl e2e test to avoid PR blockage.

More details can be found https://github.com/kubeflow/manifests/pull/1719#issuecomment-763947044

/cc @yanniszark 