### PR TITLE
Migrate to new test-infra

### DIFF
--- a/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
+++ b/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py
@@ -299,7 +299,7 @@ class Builder(object):
         {"name": "TEST_TARGET_NAME",
          "value": self.test_target_name},
        ],
-      'image': '527798164940.dkr.ecr.us-west-2.amazonaws.com/aws-kubeflow-ci/test-worker:v1.2-branch',
+      'image': 'public.ecr.aws/j1r0q0g6/kubeflow-testing:latest',
       'imagePullPolicy': 'Always',
       'name': '',
       'resources': {'limits': {'cpu': '4', 'memory': '4Gi'},
@@ -435,7 +435,7 @@ class Builder(object):
     self.workflow = self._build_workflow()
     task_template = self._build_task_template()
     py3_template = argo_build_util.deep_copy(task_template)
-    py3_template["container"]["image"] = "527798164940.dkr.ecr.us-west-2.amazonaws.com/aws-kubeflow-ci/test-worker:v1.2-branch"
+    py3_template["container"]["image"] = "public.ecr.aws/j1r0q0g6/kubeflow-testing:latest"
     default_namespace = "kubeflow"
 
     #**************************************************************************


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Part of https://github.com/kubeflow/testing/issues/861

**Description of your changes:**
Migrate kubeflow/kfctl to new test-infra, there's no difference between old test-infra and new test-infra from users' perspective.

Note: this PR is only used to validate if migration works or not. 

/hold