### PR TITLE
Add ownerReferences to resources

### DIFF
--- a/operator.md
+++ b/operator.md
@@ -107,14 +107,13 @@ The Kubeflow operator also support multiple _KfDef_ instances deployment. It wat
 
 The operator responds to following events:
 
-* When a _KfDef_ instance is created or updated, the operator's _reconciler_ will be notified of the event and invoke the `Apply` function provided by the [`kfctl` package](https://github.com/kubeflow/kfctl/tree/master/pkg) to deploy Kubeflow. The Kubeflow resources specified with the manifests will be added with the following annotation to indicate that they are owned by this _KfDef_ instance.
+* When a _KfDef_ instance is created or updated, the operator's _reconciler_
+ will be notified of the event and invoke the `Apply` function provided by
+ the [`kfctl` package](https://github.com/kubeflow/kfctl/tree/master/pkg) to
+ deploy Kubeflow. The Kubeflow resources specified with the manifests will
+ have KfDef object in their ownerReferences field to indicate that they are
+ owned by this _KfDef_ instance.
   
-  ```
-  annotations:
-    kfctl.kubeflow.io/kfdef-instance: <kfdef-name>.<kfdef-namespace>
-  ```
-  
-
 * When a _KfDef_ instance is deleted, the operator's _reconciler_ will be notified of the event and invoke the finalizer to run the `Delete` function provided by the [`kfctl` package](https://github.com/kubeflow/kfctl/tree/master/pkg) and go through all applications and components owned by the _KfDef_ instance.
 
 * When any resource deployed as part of a _KfDef_ instance is deleted, the operator's _reconciler_ will be notified of the event and invoke the `Apply` function provided by the [`kfctl` package](https://github.com/kubeflow/kfctl/tree/master/pkg) to re-deploy Kubeflow. The deleted resource will be recreated with the same manifest which was specified when the _KfDef_ instance was created.

--- a/pkg/kfapp/kustomize/kustomize_test.go
+++ b/pkg/kfapp/kustomize/kustomize_test.go
@@ -111,7 +111,7 @@ func TestGenerateYamlWithOperatorAnnotation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to evaluate manifest. Error: %v.", err)
 		}
-		actual, err := GenerateYamlWithOperatorAnnotation(resMap, instance)
+		actual, err := GenerateYamlWithOwnerReference(resMap, instance)
 		if err != nil {
 			t.Fatalf("Failed to add owner reference. Error: %v.", err)
 		}

--- a/pkg/kfapp/kustomize/testdata/operator/expected/service.yaml
+++ b/pkg/kfapp/kustomize/testdata/operator/expected/service.yaml
@@ -1,12 +1,17 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kfctl.kubeflow.io/kfdef-instance: operator.kubeflow
   labels:
     app: fake
   name: fake-service
   namespace: kubeflow
+  ownerReferences:
+  - apiVersion: kfdef.apps.kubeflow.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: KfDef
+    name: operator
+    uid: ""
 spec:
   ports:
   - port: 9000

--- a/pkg/utils/k8utils.go
+++ b/pkg/utils/k8utils.go
@@ -64,7 +64,7 @@ const (
 	katibMetricsCollectorLabel = "katib-metricscollector-injection"
 	KfDefAnnotation            = "kfctl.kubeflow.io"
 	ForceDelete                = "force-delete"
-	SetAnnotation              = "set-kubeflow-annotation"
+	SetOwnerReference          = "set-owner-reference"
 	KfDefInstance              = "kfdef-instance"
 	InstallByOperator          = "install-by-operator"
 )


### PR DESCRIPTION
Closes #460 
This commit is responsible for following changes:

- Adds owner references to all the resources in the manifest repo.
- It also removes the `kfctl.kubeflow.io/kfdef-instance: <kfdef-name>.<kfdef-namespace>`
annotation, since its no longer required. The owner references field now indicates that
resources are owned by KfDef instance.

Ref PR: https://github.com/kubeflow/kfctl/pull/271