### PR TITLE
Bugfixes: Fixing AWS infra_configs change, and logging error in aws.go

### DIFF
--- a/pkg/kfapp/aws/aws.go
+++ b/pkg/kfapp/aws/aws.go
@@ -308,7 +308,11 @@ func (aws *Aws) generateInfraConfigs() error {
 		log.Infof("Creating AWS infrastructure configs in directory %v", destDir)
 		destDirErr := os.MkdirAll(destDir, os.ModePerm)
 		if destDirErr != nil {
-			return destDirErr
+			return &kfapis.KfError{
+				Code: destDirErr.(*kfapis.KfError).Code,
+				Message: fmt.Sprintf("Could not create directory %v: %v",
+					destDir, destDirErr.(*kfapis.KfError).Message),
+			}
 		}
 	} else {
 		log.Infof("AWS infrastructure configs already exist in directory %v", destDir)
@@ -317,7 +321,11 @@ func (aws *Aws) generateInfraConfigs() error {
 	// List all the files under source directory
 	files, err := ioutil.ReadDir(sourceDir)
 	if err != nil {
-		return err
+		return &kfapis.KfError{
+				Code: err.(*kfapis.KfError).Code,
+				Message: fmt.Sprintf("Could not list files in source directory %v: %v",
+					sourceDir, err.(*kfapis.KfError).Message),
+			}
 	}
 
 	for _, file := range files {
@@ -927,7 +935,7 @@ func (aws *Aws) deleteIamRolePolicy(roleName, policyName string) error {
 
 // attachIamInlinePolicy attach inline policy to IAM role
 func (aws *Aws) attachIamInlinePolicy(roleName, policyName, policyDocumentPath string) error {
-	log.Infof("Attaching inline policy %s for iam role %s", policyName, roleName)
+	log.Infof("Attaching inline policy %s for iam role %s: from file: %s", policyName, roleName, policyDocumentPath)
 	policyDocumentJSONBytes, _ := ioutil.ReadFile(policyDocumentPath)
 
 	input := &iam.PutRolePolicyInput{

--- a/pkg/kfapp/aws/aws.go
+++ b/pkg/kfapp/aws/aws.go
@@ -56,7 +56,7 @@ const (
 	PATH                   = "path"
 	BASIC_AUTH_SECRET      = "kubeflow-login"
 	// Path in manifests repo to where the additional configs are located
-	CONFIG_LOCAL_PATH = "aws/infra_configs"
+	CONFIG_LOCAL_PATH = "distributions/aws/infra_configs"
 
 	ALB_OIDC_SECRET = "alb-oidc-secret"
 
@@ -308,6 +308,7 @@ func (aws *Aws) generateInfraConfigs() error {
 		log.Infof("Creating AWS infrastructure configs in directory %v", destDir)
 		destDirErr := os.MkdirAll(destDir, os.ModePerm)
 		if destDirErr != nil {
+			log.Errorf("There was a problem creating the directory; %v", destDirErr)
 			return &kfapis.KfError{
 				Code: destDirErr.(*kfapis.KfError).Code,
 				Message: fmt.Sprintf("Could not create directory %v: %v",
@@ -319,8 +320,10 @@ func (aws *Aws) generateInfraConfigs() error {
 	}
 
 	// List all the files under source directory
+	log.Infof("Reading source directory: %v", sourceDir)
 	files, err := ioutil.ReadDir(sourceDir)
 	if err != nil {
+		log.Errorf("There was a problem reading the source directory; %v", err)
 		return &kfapis.KfError{
 				Code: err.(*kfapis.KfError).Code,
 				Message: fmt.Sprintf("Could not list files in source directory %v: %v",
@@ -328,11 +331,13 @@ func (aws *Aws) generateInfraConfigs() error {
 			}
 	}
 
+	log.Infof("Copying aws_config files...")
 	for _, file := range files {
 		sourceFile := filepath.Join(sourceDir, file.Name())
 		destFile := filepath.Join(destDir, file.Name())
 		copyErr := copyFile(sourceFile, destFile)
 		if copyErr != nil {
+			log.Errorf("There was a problem copying file: %v to %v: %v", sourceFile, destFile, copyErr)
 			return &kfapis.KfError{
 				Code: copyErr.(*kfapis.KfError).Code,
 				Message: fmt.Sprintf("Could not copy %v to %v: %v",
@@ -343,6 +348,7 @@ func (aws *Aws) generateInfraConfigs() error {
 
 	// 2. Reading from cluster_config.yaml and replace placeholders with values in aws.kfDef.Spec.
 	clusterConfigFile := filepath.Join(destDir, CLUSTER_CONFIG_FILE)
+	log.Infof("Updating cluster_config from file: %v", clusterConfigFile)
 	if err := aws.updateClusterConfig(clusterConfigFile); err != nil {
 		return err
 	}


### PR DESCRIPTION
# Overview

There were two errors which caused the deployment on AWS to fail.

1) The original error is that AWS resources (IAM Policy documents and such) were moved from `aws/infra_configs` to `distributions/aws/infra_configs` in https://github.com/kubeflow/manifests/tree/master/distributions/aws/infra_configs

2) There was an error handling bug in `kfctl`, which caused `kfctl` to panic and crash.

This PR fixes both.

### `infra_configs` fix

This was fixed by simply changing the constant to point to `distributions/aws/infra_configs`.


### Logging fix

`kfctl` was crashing after creating the `aws_config`root directory. 

```
INFO[0002] Creating AWS infrastructure configs in directory /home/dev/repos/03-kubeflow/rokt-kubeflow/tmp/_config/kubeflow/aws_config  filename="aws/aws.go:308"
panic: interface conversion: error is *os.PathError, not *apis.KfError

goroutine 1 [running]:
github.com/kubeflow/kfctl/v3/pkg/kfapp/aws.(*Aws).Generate(0xc00014aa00, 0x231639a, 0x3, 0x3, 0xc000850508)
	/Users/jiaxin/go/src/github.com/kubeflow/kfctl/pkg/kfapp/aws/aws.go:444 +0x2a6d
github.com/kubeflow/kfctl/v3/pkg/kfapp/coordinator.(*coordinator).Generate.func1(0xc0001cca00, 0x0)
	/Users/jiaxin/go/src/github.com/kubeflow/kfctl/pkg/kfapp/coordinator/coordinator.go:537 +0xe3
github.com/kubeflow/kfctl/v3/pkg/kfapp/coordinator.(*coordinator).Generate(0xc0004ee8e0, 0x231639a, 0x3, 0x0, 0x0)
	/Users/jiaxin/go/src/github.com/kubeflow/kfctl/pkg/kfapp/coordinator/coordinator.go:590 +0x241
github.com/kubeflow/kfctl/v3/pkg/kfapp/coordinator.NewLoadKfAppFromURI(0x7ffdfd2cf3da, 0x49, 0xc0006b5d9a, 0x5, 0x0, 0x0)
	/Users/jiaxin/go/src/github.com/kubeflow/kfctl/pkg/kfapp/coordinator/coordinator.go:236 +0x47b
github.com/kubeflow/kfctl/v3/cmd/kfctl/cmd.glob..func2(0x393bca0, 0xc000668c00, 0x0, 0x3, 0x0, 0x0)
	/Users/jiaxin/go/src/github.com/kubeflow/kfctl/cmd/kfctl/cmd/build.go:51 +0x1de
github.com/spf13/cobra.(*Command).execute(0x393bca0, 0xc000668bd0, 0x3, 0x3, 0x393bca0, 0xc000668bd0)
	/Users/jiaxin/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:842 +0x453
github.com/spf13/cobra.(*Command).ExecuteC(0x393d1a0, 0xc0003bbf20, 0xc00078ff48, 0x1c61b60)
	/Users/jiaxin/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x349
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/jiaxin/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
github.com/kubeflow/kfctl/v3/cmd/kfctl/cmd.Execute(0x2703ff0, 0x11)
	/Users/jiaxin/go/src/github.com/kubeflow/kfctl/cmd/kfctl/cmd/root.go:61 +0x56
main.main()
	/Users/jiaxin/go/src/github.com/kubeflow/kfctl/cmd/kfctl/main.go:36 +0x39
m
```

The error is caused by the line that tries to print the error. It is expecting an `apis.KfError`, but instead it got an os.PathError.

I have fixed this by converting os.PathError to `apis.KfError`.

